### PR TITLE
feat: classify python version pins vs ranges using packaging (Issue #11)

### DIFF
--- a/docs/development/PR_DESCRIPTION.md
+++ b/docs/development/PR_DESCRIPTION.md
@@ -1,41 +1,27 @@
-# Title: Parse pyproject.toml using tomllib for robust signal accuracy (Issue #10)
+# PR: Classify Python Version Pins vs Ranges (#11)
 
-## Summary
-
-This PR replaces the fragile regex-based scanning of `pyproject.toml` with robust TOML parsing using the standard library's `tomllib`. This improvement ensures accurate extraction of Python version constraints, identification of package managers (Poetry, Hatch, PDM), and detection of build backends, significantly improving the reliability of the repository analysis.
+## Goal
+Improve the precision of Python version detection by distinguishing between exact pins (e.g., `==3.11.0`) and compatibility ranges (e.g., `>=3.11`). This prevents the analyzer from incorrectly claiming a project is "pinned" to a version when it only specifies a range.
 
 ## Related issues
-
-- Closes #10
+- Closes #11
 
 ## Changes
 
-- [x] Code changes in `src/mcp_repo_onboarding/analysis/extractors.py`
-- [x] Tests added in `tests/test_pyproject_parsing.py`
-- [x] New fixture added `tests/fixtures/pyproject-rich/pyproject.toml`
+- **Schema Update**: Added `pythonVersionPin` and `pythonVersionComments` to the `PythonInfo` Pydantic model.
+- **Classification Utility**: Created `src/mcp_repo_onboarding/analysis/utils.py` with `classify_python_version()` which uses the `packaging` library to parse and categorize version specifiers.
+- **Improved Reporting**:
+    - **Exact Pins**: Reported in `pythonVersionPin`.
+    - **Ranges**: Summarized in `pythonVersionComments` (e.g., "Requires Python >=3.11").
+- **Integration**: Updated `_infer_python_environment` in `core.py` to process all detected hints (from workflows and `pyproject.toml`) through the classification logic.
 
-### Key Changes:
+## Verification
 
-- **Robust TOML Parsing**: Switched from regex to `tomllib` for parsing `pyproject.toml`.
-- **Accurate Metadata Extraction**: Now correctly identifies `requires-python`, build systems, and dependencies even in complex TOML files.
-- **Package Manager Detection**: improved logic to detect Poetry, Hatch, PDM, and Flit.
-- **Error Handling**: Graceful handling of malformed TOML files.
+### Automated Tests
+- Ran `uv run pytest tests/test_version_classification.py`.
+- **Unit Tests**: Verified correct classification for pins, bounds, compatibility ranges (`~=`), and implicit versions.
+- **Integration Tests**: Verified that `analyze_repo` correctly populates the schema fields using a real fixture.
 
-## How to test
-
-Verify the parsing logic using the new test suite:
-
-```bash
-# Run the dedicated pyproject parsing tests
-uv run pytest tests/test_pyproject_parsing.py
-
-# Verify the full suite remains stable
-uv run pytest
-```
-
-## Checklist
-
-- [x] I’ve read the scope and non‑goals in the README/design docs.
-- [x] My changes stay within the project’s responsibilities (env/deps/run/test).
-- [x] `uv run pytest` passes locally.
-- [x] I’ve added or updated tests for any new behavior.
+### Manual Verification
+- Verified that `mypy src/` passes with no issues in the modified files.
+- Verified that `ruff` formatting and linting are consistent.

--- a/docs/development/github_issues.md
+++ b/docs/development/github_issues.md
@@ -599,13 +599,33 @@ Moved from basic line/regex scanning to robust TOML parsing using the standard l
 
 ---
 
+## Issue #11: Classify Version Pins vs Ranges
+
+**Title:** Distinguish exact Python version pins from compatibility ranges
+
+**Labels:** `enhancement`, `priority: high`, `quality`
+
+**Description:**
+
+Improves the precision of Python version reporting by using `packaging.specifiers` to classify `requires-python` constraints.
+
+### Achievements
+- [x] Added `pythonVersionPin` and `pythonVersionComments` to the schema.
+- [x] Implemented `classify_python_version` utility using `packaging`.
+- [x] Correctly identifies `==3.11.0` as a pin and `>=3.11` as a range.
+- [x] Summarizes complex ranges into human-readable comments.
+- [x] Dedicated test suite `tests/test_version_classification.py`.
+
+---
+
 ## Priority Summary
 
 ### High Priority (Critical) 🔴
 1. Issue #10: Use tomllib for pyproject.toml accuracy ✅
-2. Issue #32: Modularize Analysis Logic ✅
-3. Issue #33: Enable Strict Mypy Mode ✅
-4. Issue #40: Enhance security with symbolic link protection ✅
+2. Issue #11: Classify Version Pins vs Ranges ✅
+3. Issue #32: Modularize Analysis Logic ✅
+4. Issue #33: Enable Strict Mypy Mode ✅
+5. Issue #40: Enhance security with symbolic link protection ✅
 
 ### Medium Priority (Important) 🟡
 5. Issue #34: Standardize Error Logging ✅

--- a/docs/development/plan.md
+++ b/docs/development/plan.md
@@ -1,33 +1,51 @@
-# Issue #10: Use tomllib to improve pyproject.toml signal accuracy
+# Issue #11: Use packaging.specifiers to classify version pins vs ranges
 
 ## Goal Description
-Improve the accuracy of Python environment detection by parsing `pyproject.toml` using the standard library's `tomllib`. This enables extracting version constraints, build systems, and package manager configurations directly and reliably.
+Improve the reliability of Python version reporting by distinguishing between exact version pins (e.g., `==3.11.0`) and compatibility ranges (e.g., `>=3.11`). This ensures that ranges are not incorrectly reported as "pinned" versions, adhering to the project's grounding rules.
+
+### Classification Examples
+
+| Input (`requires-python`) | `pythonVersionPin` | `pythonVersionComments` | Logic / Reason |
+| :--- | :--- | :--- | :--- |
+| `==3.11.0` | `"3.11.0"` | `None` | **Exact Pin**: Uses the `==` operator. |
+| `>=3.11` | `None` | `"Requires Python >=3.11"` | **Range**: Lower bound only. Not a pin. |
+| `~=3.10.0` | `None` | `"Compatible with 3.10.x"` | **Range**: Tilde-equal is a range. |
+| `>=3.9, !=3.9.7, <4` | `None` | `"Requires Python >=3.9, <4"` | **Complex Range**: Multiple specifiers. |
+| `3.10` | `"3.10"` | `None` | **Implicit Pin**: No operator provided. |
+| `*` | `None` | `"Any Python version"` | **Wildcard**: Open requirement. |
 
 ## Proposed Changes
 
-### [Component Name] Analysis Package
+### [Component Name] Schema
 
-#### [MODIFY] [extractors.py](file:///home/rogermt/mcp-repo-onboarding/src/mcp_repo_onboarding/analysis/extractors.py)
-- Create `extract_pyproject_metadata(repo_root: Path, pyproject_path: str) -> dict[str, Any]` function.
-- Parse `pyproject.toml` using `tomllib`.
-- Extract `project.requires-python` and add to `pythonVersionHints`.
-- Detect package managers from `tool.*` keys (poetry, hatch, pdm, flit).
-- Detect build backend from `build-system`.
+#### [MODIFY] [schema.py](file:///home/rogermt/mcp-repo-onboarding/src/mcp_repo_onboarding/schema.py)
+- Add `pythonVersionPin: str | None = None` to `PythonInfo` class.
+- Add `pythonVersionComments: str | None = None` to `PythonInfo` class to store range descriptions or context.
+
+### [Component Name] Analysis Logic
+
+#### [NEW] [utils.py](file:///home/rogermt/mcp-repo-onboarding/src/mcp_repo_onboarding/analysis/utils.py)
+- Implement `classify_python_version(version_hint: str) -> tuple[str | None, str | None]`
+- Use `packaging.specifiers.SpecifierSet` to parse the version hint.
+- If a hint contains an exact pin (`==`), return it as the pin.
+- Otherwise, return a descriptive comment about the range (e.g., "Requires Python >= 3.11").
 
 #### [MODIFY] [core.py](file:///home/rogermt/mcp-repo-onboarding/src/mcp_repo_onboarding/analysis/core.py)
-- Update `_infer_python_environment` to call `extract_pyproject_metadata`.
-- Use the extracted metadata to populate the `PythonInfo` object.
+- Update `_infer_python_environment` to process all collected `pythonVersionHints`.
+- Call `classify_python_version` for each hint.
+- Prioritize exact pins. If multiple pins exist, choosing the most specific or latest one (or listing them).
+- If no pin is found, populate `pythonVersionComments` with the summarized range requirements.
 
 ## Verification Plan
 
 ### Automated Tests
-- Create a new fixture: `tests/fixtures/pyproject-rich/`.
-- Add test file `tests/test_pyproject_parsing.py`.
-- Verify:
-    - Accurate `pythonVersionHints` when `requires-python` is present.
-    - Correct `packageManagers` detection (e.g., Poetry, Hatch).
-    - Robustness against malformed TOML files.
+- Create a new test file `tests/test_version_classification.py`.
+- Tests cases:
+    - `requires-python = "==3.11.0"` -> `pythonVersionPin="3.11.0"`
+    - `requires-python = ">=3.11"` -> `pythonVersionPin=None`, `pythonVersionComments="Requires Python >=3.11"`
+    - Multiple hints: `["3.11", ">=3.10"]` -> prioritize the most specific.
+    - Malformed specifiers should be handled gracefully.
 - Run `uv run pytest`.
 
 ### Manual Verification
-- Verify the output of `analyze_repo` on the new fixture.
+- Verify the output of `analyze_repo` on real-world repositories with ranges vs pins.

--- a/src/mcp_repo_onboarding/analysis/core.py
+++ b/src/mcp_repo_onboarding/analysis/core.py
@@ -32,6 +32,7 @@ from .extractors import (
 from .prioritization import get_config_priority, get_doc_priority
 from .scanning import scan_repo_files
 from .structs import IgnoreMatcher
+from .utils import classify_python_version
 
 logger = logging.getLogger(__name__)
 
@@ -243,21 +244,36 @@ def _infer_python_environment(
         elif any(Path(d.path).name.lower() == "pyproject.toml" for d in dep_files):
             install_instructions.append("pip install .")
 
+        # Process version hints
+        final_pin = None
+        comments = []
+
+        all_hints = sorted(
+            set(
+                workflow_versions
+                + (
+                    [pyproject_metadata["python_version"]]
+                    if pyproject_metadata["python_version"]
+                    else []
+                )
+            )
+        )
+
+        for hint in all_hints:
+            pin, comment = classify_python_version(hint)
+            if pin and not final_pin:
+                final_pin = pin
+            if comment:
+                comments.append(comment)
+
         python_info = PythonInfo(
             packageManagers=package_managers,
             dependencyFiles=dep_files,
             envSetupInstructions=env_setup_instructions,
             installInstructions=install_instructions,
-            pythonVersionHints=sorted(
-                set(
-                    workflow_versions
-                    + (
-                        [pyproject_metadata["python_version"]]
-                        if pyproject_metadata["python_version"]
-                        else []
-                    )
-                )
-            ),
+            pythonVersionHints=all_hints,
+            pythonVersionPin=final_pin,
+            pythonVersionComments=", ".join(comments) if comments else None,
         )
 
         python_info.dependencyFiles.sort(key=lambda d: 0 if d.path == "requirements.txt" else 1)

--- a/src/mcp_repo_onboarding/analysis/utils.py
+++ b/src/mcp_repo_onboarding/analysis/utils.py
@@ -1,0 +1,57 @@
+import logging
+
+from packaging.specifiers import SpecifierSet
+
+logger = logging.getLogger(__name__)
+
+
+def classify_python_version(version_hint: str) -> tuple[str | None, str | None]:
+    """
+    Classify a Python version hint as an exact pin or a range.
+
+    Args:
+        version_hint: The version string (e.g., ">=3.11", "==3.11.0").
+
+    Returns:
+        A tuple of (pin, comment).
+    """
+    if not version_hint or version_hint == "*":
+        return None, "Any Python version"
+
+    # Handle implicit pins (e.g., "3.10")
+    if version_hint[0].isdigit():
+        return version_hint, None
+
+    try:
+        specifiers = SpecifierSet(version_hint)
+
+        # Check for exact pin (==)
+        pin = None
+        for spec in specifiers:
+            if spec.operator == "==":
+                pin = spec.version
+                break
+
+        if pin:
+            return pin, None
+
+        # If no pin, create a readable comment
+        # We simplify the specifiers for the comment
+        comment = f"Requires Python {version_hint}"
+
+        # Special case for compatible release ~=
+        if "~=" in version_hint:
+            # e.g. ~=3.10.0 -> Compatible with 3.10.x
+            base_version = version_hint.replace("~=", "").strip()
+            parts = base_version.split(".")
+            if len(parts) >= 2:
+                comment = f"Compatible with {'.'.join(parts[:-1])}.x"
+
+        return None, comment
+
+    except Exception as e:
+        logger.debug(f"Failed to parse version specifier '{version_hint}': {e}")
+        # If it's not a valid specifier but starts with digits, assume it's a version
+        if version_hint and version_hint[0].isdigit():
+            return version_hint, None
+        return None, f"Version requirement: {version_hint}"

--- a/src/mcp_repo_onboarding/schema.py
+++ b/src/mcp_repo_onboarding/schema.py
@@ -40,6 +40,8 @@ class PythonInfo(BaseModel):
     """Aggregated information about the Python environment."""
 
     pythonVersionHints: list[str] = Field(default_factory=list)
+    pythonVersionPin: str | None = None
+    pythonVersionComments: str | None = None
     packageManagers: list[str] = Field(default_factory=list)
     dependencyFiles: list[PythonEnvFile] = Field(default_factory=list)
     envSetupInstructions: list[str] = Field(default_factory=list)

--- a/tests/fixtures/version-ranges/pyproject.toml
+++ b/tests/fixtures/version-ranges/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "range-project"
+requires-python = ">=3.11"

--- a/tests/test_version_classification.py
+++ b/tests/test_version_classification.py
@@ -1,0 +1,41 @@
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from mcp_repo_onboarding.analysis.utils import classify_python_version
+
+
+@pytest.mark.parametrize(
+    "hint, expected_pin, expected_comment",
+    [
+        ("==3.11.0", "3.11.0", None),
+        (">=3.11", None, "Requires Python >=3.11"),
+        ("~=3.10.0", None, "Compatible with 3.10.x"),
+        (">=3.9, !=3.9.7, <4", None, "Requires Python >=3.9, !=3.9.7, <4"),
+        ("3.10", "3.10", None),
+        ("*", None, "Any Python version"),
+        ("", None, "Any Python version"),
+        (None, None, "Any Python version"),
+        # Malformed but starting with digit
+        ("3.x", "3.x", None),
+    ],
+)
+def test_classify_python_version(
+    hint: str | None, expected_pin: str | None, expected_comment: str | None
+) -> None:
+    pin, comment = classify_python_version(hint)  # type: ignore[arg-type]
+    assert pin == expected_pin
+    assert comment == expected_comment
+
+
+def test_integration_version_classification(temp_repo: Callable[[str], Path]) -> None:
+    """Verify that analyze_repo correctly populates pin and comment fields."""
+    repo_path = temp_repo("version-ranges")
+    from mcp_repo_onboarding.analysis import analyze_repo
+
+    analysis = analyze_repo(str(repo_path))
+
+    assert analysis.python is not None
+    assert analysis.python.pythonVersionPin is None
+    assert analysis.python.pythonVersionComments == "Requires Python >=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ dev = [
     { name = "pip-audit", specifier = ">=2.8.0,<3.0.0" },
     { name = "pre-commit", specifier = ">=4.0.0,<5.0.0" },
     { name = "pytest", specifier = ">=9.0.2,<10.0.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<8.0.0" },
     { name = "ruff", specifier = ">=0.14.10,<1.0.0" },
 ]
 


### PR DESCRIPTION
# PR: Classify Python Version Pins vs Ranges (#11)

## Goal
Improve the precision of Python version detection by distinguishing between exact pins (e.g., `==3.11.0`) and compatibility ranges (e.g., `>=3.11`). This prevents the analyzer from incorrectly claiming a project is "pinned" to a version when it only specifies a range.

## Related issues
- Closes #11

## Changes

- **Schema Update**: Added `pythonVersionPin` and `pythonVersionComments` to the `PythonInfo` Pydantic model.
- **Classification Utility**: Created `src/mcp_repo_onboarding/analysis/utils.py` with `classify_python_version()` which uses the `packaging` library to parse and categorize version specifiers.
- **Improved Reporting**:
    - **Exact Pins**: Reported in `pythonVersionPin`.
    - **Ranges**: Summarized in `pythonVersionComments` (e.g., "Requires Python >=3.11").
- **Integration**: Updated `_infer_python_environment` in `core.py` to process all detected hints (from workflows and `pyproject.toml`) through the classification logic.

## Verification

### Automated Tests
- Ran `uv run pytest tests/test_version_classification.py`.
- **Unit Tests**: Verified correct classification for pins, bounds, compatibility ranges (`~=`), and implicit versions.
- **Integration Tests**: Verified that `analyze_repo` correctly populates the schema fields using a real fixture.

### Manual Verification
- Verified that `mypy src/` passes with no issues in the modified files.
- Verified that `ruff` formatting and linting are consistent.