### PR TITLE
feature: narrow evidence strings (“key symbols”) for framework/entryp…

### DIFF
--- a/docs/evaluation/B-prompt.txt
+++ b/docs/evaluation/B-prompt.txt
@@ -30,13 +30,14 @@ From `analyze_repo`, extract:
 - python.pythonVersionHints
 - python.dependencyFiles
 - python.envSetupInstructions
+- python.installInstructions
 - projectLayout
 - scripts
-- frameworks
+- frameworks (including frameworks[].name, frameworks[].detectionReason, and if present: frameworks[].keySymbols, frameworks[].evidencePath)
 - configurationFiles
 - docs
 - notes
-- notebooks  (If present: list of directories containing .ipynb files)
+- notebooks (if present: list of directories containing .ipynb files)
 
 From `get_run_and_test_commands`, extract:
 - devCommands, testCommands, buildCommands.
@@ -50,31 +51,105 @@ Step 3 — Grounding rules (Hard rules):
 * `python3 -m venv .venv` (Create virtual environment.)
 * `source .venv/bin/activate` (Activate virtual environment.)
 - Commands: ONLY include commands that appear in `scripts.*`, `testSetup.commands`, or `get_run_and_test_commands`.
-- Install Commands Priority: If `make install` is detected, it MUST be the primary and SOLE install command. Do not invent `pip install` commands if `make install` is present. If `make install` is absent, use the install commands provided by MCP output (`python.installInstructions` or `scripts.install`). Do NOT invent `pip install -r` commands from `python.dependencyFiles`. Max ONE `pip install -r` line allowed.
+
+Install Commands Priority (hard rule):
+- If `make install` is detected, it MUST be the primary and SOLE install command.
+- Do not invent `pip install` commands if `make install` is present.
+- If `make install` is absent, use install commands provided by MCP output (`python.installInstructions` or `scripts.install`).
+- Do NOT invent `pip install -r` commands from `python.dependencyFiles`.
+- Max ONE `pip install -r` line allowed.
+
 - Signal Provenance: If `SHOW_PROVENANCE` is true, append (source: <source>) using the exact `source` value from MCP output. If `SHOW_PROVENANCE` is false, omit provenance entirely.
 - Never present Makefile recipe internals as commands.
-- Command Formatting Rule (hard rule): Every command bullet MUST follow the format:
+
+Command Formatting Rule (hard rule):
+- Every command bullet MUST follow the format:
   `* `command` (Brief description.)`
-  Use a space between the backtick and opening parenthesis.
-  Do NOT use dashes or colons between the command and description.
-- Confidence: If a command/signal has `confidence: "heuristic"`, label it as "(Generic suggestion)" on the line above.
+- Use a space between the backtick and opening parenthesis.
+- Do NOT use dashes or colons between the command and description.
+
+Generic suggestion wording (hard rule):
+- Do NOT use the phrase "Generic suggestion" as the parenthesized description of a command bullet.
+- If you must mark something as generic, use a standalone "(Generic suggestion)" line above it (only where allowed by this prompt).
+
+Confidence rule (hard rule):
+- If a command/signal has `confidence: "heuristic"`, label it as "(Generic suggestion)" on the line above.
+
+No-commands sentence (hard rule):
+- The ONLY allowed no-commands sentence anywhere in ONBOARDING.md is exactly:
+  "No explicit commands detected."
+- Do NOT write any variants such as:
+  "No explicit format commands detected."
+  "No explicit lint commands detected."
+  "No explicit install commands detected."
+  "No explicit dev commands detected."
 
 Notebook-centric rule (informational only):
 - If `notebooks` is present and non-empty OR notes include the notebook-centric message, add a bullet in `## Analyzer notes` indicating:
   "Notebook-centric repo detected; core logic may reside in Jupyter notebooks."
 - Also include a bullet listing notebook directories, e.g.:
   "* Notebooks found in: notebooks/, research/"
+- Do NOT prescribe a runner (Kaggle/Colab/local). Do NOT assume notebook kernel language.
 
-Do NOT prescribe a runner (Kaggle/Colab/local). Do NOT assume notebook kernel language.
+Framework proof (hard rule):
+- Treat frameworks[].keySymbols / frameworks[].evidencePath as internal grounding only.
+- Do NOT print keySymbols or evidencePath in ONBOARDING.md.
+- When SHOW_PROVENANCE is false, do NOT output any lines containing the substrings "source:" or "evidence:" anywhere in ONBOARDING.md.
 
 Step 4 — Produce ONBOARDING.md (copy/pasteable):
 Bullet points in the document ALWAYS use `*`.
+
+Required section rule (hard rule):
+- You MUST include ALL required headings from the validator contract in the exact order:
+  ## Overview
+  ## Environment setup
+  ## Install dependencies
+  ## Run / develop locally
+  ## Run tests
+  ## Lint / format
+  ## Dependency files detected
+  ## Useful configuration files
+  ## Useful docs
+- Even if a section has no items, you MUST still include the heading.
+  - For command sections, use: "No explicit commands detected."
+  - For Dependency files detected, if python.dependencyFiles is empty or missing, write:
+    "No dependency files detected."
+
+Section placement rule (hard rule):
+- If you include "## Analyzer notes", it MUST appear immediately AFTER "## Lint / format"
+  and BEFORE "## Dependency files detected".
+- Do NOT move "## Analyzer notes" to the end of the document.
 
 **Heading rule (hard rule):**
 - Use the heading exactly: `## Environment setup` (do not write `## Environment` and do not add parentheses like `(Python 3.14)` in the heading).
 - The first line under `## Environment setup` must be the Python version statement:
   - If `python.pythonVersionHints` is non-empty: `Python version: <value>`
   - If empty: `No Python version pin detected.` (DO NOT prefix with "Python version:").
+
+Command section content rule (hard rule):
+For each of these sections:
+- ## Install dependencies
+- ## Run / develop locally
+- ## Run tests
+- ## Lint / format
+
+Output MUST be exactly one of:
+A) One or more bullet lines of the form: "* `command` (Description.)"
+OR
+B) A single standalone line: "No explicit commands detected."
+
+Do NOT output any additional explanatory lines if the section already contains at least one command bullet.
+
+Lint / format is a combined section:
+- Include any lint commands and any format commands together as bullets in the same section.
+- Do not add separate sub-headings or separate fallback sentences for lint vs format.
+
+Backticks usage (hard rule):
+- Use backticks ONLY for commands in the command sections.
+- Do NOT wrap file paths in backticks in:
+  - ## Dependency files detected
+  - ## Useful configuration files
+  - ## Useful docs
 
 The document MUST start exactly like this:
 
@@ -90,21 +165,45 @@ Continue with these headings exactly:
 ## Run tests
 ## Lint / format
 
-Rules for empty command sections:
-- If no commands exist for a section, write exactly: "No explicit commands detected."
-
 Section routing rule (hard rule):
 - Only put venv/activation commands in Environment setup.
 - Only put package install commands in Install dependencies.
-- If a `pip install ...` command is present anywhere in extracted MCP evidence, you MUST NOT output “No explicit install commands detected.”
+- If a `pip install ...` command is present anywhere in extracted MCP evidence, you MUST NOT output “No explicit commands detected.”
 
 ## Analyzer notes
-- Include ONLY if `notes` is not empty OR notebook-centric detection applies.
+- Include ONLY if `notes` is not empty OR notebook-centric detection applies OR frameworks are detected.
 - List notes verbatim as bullet points.
 - If notebook directories are available (analyze_repo.notebooks), add a bullet listing them (informational only).
+- List analyzer notes verbatim first, then add the frameworks bullet.
+
+Frameworks (informational only; hard formatting rule):
+- If analyze_repo.frameworks is non-empty, add exactly ONE bullet in ## Analyzer notes.
+- The bullet MUST match this exact template:
+
+  * Frameworks detected (from analyzer): <names>. (<reason>.)
+
+  Where:
+  - <names> is frameworks[].name joined by ", " and MUST end with a period.
+  - There MUST be exactly one space before the opening parenthesis.
+  - <reason> is either:
+    - the single framework's detectionReason (if exactly one framework), OR
+    - the shared detectionReason (if multiple frameworks and ALL share the same detectionReason), OR
+    - omit the entire parenthesized reason if there is no shared reason.
+  - The parenthesized reason MUST end with a period.
+
+Examples:
+* Frameworks detected (from analyzer): Flask. (Flask support detected via pyproject.toml (Poetry) dependency key 'flask' (optional).)
+* Frameworks detected (from analyzer): Django, Wagtail. (Detected via pyproject.toml classifiers.)
+
+Safety:
+- Do NOT print frameworks[].keySymbols or frameworks[].evidencePath.
+- Do NOT use the literal labels "source:" or "evidence:" anywhere.
 
 ## Dependency files detected
 - List `python.dependencyFiles[*].path` as bullets.
+- If a dependency file has a `description`, include it in parentheses after the path.
+- If python.dependencyFiles is empty or missing, write exactly:
+  "No dependency files detected."
 
 ## Useful configuration files
 - List `configurationFiles[*].path` as bullets.
@@ -123,5 +222,9 @@ You MUST call `write_onboarding` to persist the changes:
 
 Step 6 — Token usage:
 At the end of your response, write: "Token usage: <value if available, else unknown>"
+
+Token usage placement (hard rule):
+- The "Token usage: ..." line MUST NOT be included in the ONBOARDING.md content.
+- It must appear only in your final chat response after calling write_onboarding.
 
 Now execute.

--- a/docs/evaluation/phase5-ab-prompts.md
+++ b/docs/evaluation/phase5-ab-prompts.md
@@ -1,16 +1,3 @@
-Here is a **copy/paste replacement** for `docs/evaluation/phase5-ab-prompts.md` updated to match the pivot and your newer output contract:
-
-- Adds the hard rule: **B run must not read repo files directly**
-- Adds token recording for A and B
-- Requires the **three separate sections**:
-  - Dependency files detected (from `python.dependencyFiles`)
-  - Useful configuration files (from `configurationFiles`)
-  - Useful docs (from `docs`)
-- Places truncation notes correctly (notes printed in “Analyzer notes”, but also requires section-local notes if you prefer)
-- Removes the mixed “Useful repo docs/files” requirement
-
----
-
 # Phase 5 A/B Evaluation Prompts (Baseline vs MCP)
 
 Purpose: measure onboarding quality **without MCP** vs **with mcp-repo-onboarding** on the same repo.
@@ -27,6 +14,32 @@ Evaluation focus (pivoted Phase 5):
 Use this run to see what Gemini produces without MCP grounding.
 
 Hard rule: do not use any MCP tools/servers in this run.
+
+```text
+You are running the Phase 5 A/B evaluation for onboarding quality.
+
+Hard rule: DO NOT use any MCP tools or MCP servers in this run.
+
+Goal: Generate an ONBOARDING.md for this repository that is accurate and copy/pastable.
+
+Rules:
+- Do not claim a Python version unless you can cite an explicit pin you found (e.g. .python-version, runtime.txt, pyproject.toml requires-python, CI config). If you did not find one, write exactly: "No Python version pin detected."
+- Do not invent run/test/lint/format/build commands. Only include a command if you can cite exactly where it came from (filename + snippet/target name).
+- If you are unsure about a command, write "Unsure" and list the exact file(s) you would check next.
+- Prefer being correct over being complete.
+
+Output format:
+1) Evidence used (bullet list of the exact files you inspected and what each contributed)
+2) ONBOARDING.md content (single Markdown document, ready to save as ONBOARDING.md)
+3) Uncertainties / follow-ups (what you could not confirm, and which file(s) to check)
+4) Token usage: <value or unknown>
+4) Token usage (if available from the UI; otherwise write "Token usage: unknown")
+
+Now produce the output.
+```
+
+
+## B) MCP Prompt (MCP)
 
 ```text
 You are running the repository onboarding signal extraction.
@@ -48,7 +61,6 @@ Rules:
 - If `SHOW_PROVENANCE` is true, append `(source: <source>)` using the exact `source` value from MCP output.
 - If `SHOW_PROVENANCE` is false, omit the source entirely (do not print `source:` or `evidence:` anywhere in ONBOARDING.md).
 
-
 Hard rule: DO NOT inspect or read repository files directly. Use only MCP tool output as evidence.
 Hard rule: DO NOT execute any shell commands, git commands, or similar external processes. You are a Scout, not an Investigator.
 
@@ -58,29 +70,85 @@ Step 1 — Call MCP tools:
 
 Step 2 — Extract Evidence (Internal use only):
 From `analyze_repo`, extract:
-- repoPath, summary, python.pythonVersionHints, python.dependencyFiles, python.envSetupInstructions, projectLayout, scripts, frameworks, configurationFiles, docs, notes.
+- repoPath
+- python.pythonVersionHints
+- python.dependencyFiles
+- python.envSetupInstructions
+- python.installInstructions
+- projectLayout
+- scripts
+- frameworks (including frameworks[].name, frameworks[].detectionReason, and if present: frameworks[].keySymbols, frameworks[].evidencePath)
+- configurationFiles
+- docs
+- notes
+- notebooks (if present: list of directories containing .ipynb files)
+
 From `get_run_and_test_commands`, extract:
 - devCommands, testCommands, buildCommands.
 
 Step 3 — Grounding rules (Hard rules):
-- Python version: ONLY mention a specific version if `python.pythonVersionHints` contains it. If empty, say: "No Python version pin detected."
-- Environment setup: If `python.pythonVersionHints` is empty and no explicit venv commands are detected, you MAY provide a standard (Generic suggestion) venv snippet:
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-```
+- Python version: ONLY mention a specific version if `python.pythonVersionHints` contains it. If empty, say exactly: "No Python version pin detected."
+- Environment setup: If `python.pythonVersionHints` is empty and no explicit venv commands are detected, you MUST provide a standard (Generic suggestion) venv snippet.
+- (Generic suggestion) Labeling Rule: The line `(Generic suggestion)` MUST appear exactly as written (no colon, no extra text) exactly ONE line above the first venv command.
+- Venv Formatting:
+(Generic suggestion)
+* `python3 -m venv .venv` (Create virtual environment.)
+* `source .venv/bin/activate` (Activate virtual environment.)
 - Commands: ONLY include commands that appear in `scripts.*`, `testSetup.commands`, or `get_run_and_test_commands`.
-- Signal Provenance: Use the `description` field from the JSON to explain why a command or framework was detected. If SHOW_PROVENANCE is true, append (source: <source>). If SHOW_PROVENANCE is false, omit the source entirely.
+- Install Commands Priority: If `make install` is detected, it MUST be the primary and SOLE install command. Do not invent `pip install` commands if `make install` is present. If `make install` is absent, use the install commands provided by MCP output (`python.installInstructions` or `scripts.install`). Do NOT invent `pip install -r` commands from `python.dependencyFiles`. Max ONE `pip install -r` line allowed.
+- Signal Provenance: If `SHOW_PROVENANCE` is true, append (source: <source>) using the exact `source` value from MCP output. If `SHOW_PROVENANCE` is false, omit provenance entirely.
 - Never present Makefile recipe internals as commands.
-- Confidence: If a command/signal has `confidence: "heuristic"`, label it as "(Generic suggestion)". Keep to 1–2 bullets max per section.
+- Command Formatting Rule (hard rule): Every command bullet MUST follow the format:
+  `* `command` (Brief description.)`
+  Use a space between the backtick and opening parenthesis.
+  Do NOT use dashes or colons between the command and description.
+- Confidence: If a command/signal has `confidence: "heuristic"`, label it as "(Generic suggestion)" on the line above.
+
+No-commands sentence (hard rule):
+- The ONLY allowed no-commands sentence anywhere in ONBOARDING.md is exactly:
+  "No explicit commands detected."
+- Do NOT write any variants such as:
+  "No explicit format commands detected."
+  "No explicit lint commands detected."
+  "No explicit install commands detected."
+  "No explicit dev commands detected."
+
+Notebook-centric rule (informational only):
+- If `notebooks` is present and non-empty OR notes include the notebook-centric message, add a bullet in `## Analyzer notes` indicating:
+  "Notebook-centric repo detected; core logic may reside in Jupyter notebooks."
+- Also include a bullet listing notebook directories, e.g.:
+  "* Notebooks found in: notebooks/, research/"
+
+Do NOT prescribe a runner (Kaggle/Colab/local). Do NOT assume notebook kernel language.
+
+Framework proof (hard rule):
+- Treat frameworks[].keySymbols / frameworks[].evidencePath as internal grounding only.
+- Do NOT print keySymbols or evidencePath in ONBOARDING.md.
+- When SHOW_PROVENANCE is false, do NOT output any lines containing the substrings "source:" or "evidence:" anywhere in ONBOARDING.md.
 
 Step 4 — Produce ONBOARDING.md (copy/pasteable):
-Bullet points in the documnet ALWAYS use * or an asterix
+Bullet points in the document ALWAYS use `*`.
+
 **Heading rule (hard rule):**
 - Use the heading exactly: `## Environment setup` (do not write `## Environment` and do not add parentheses like `(Python 3.14)` in the heading).
 - The first line under `## Environment setup` must be the Python version statement:
   - If `python.pythonVersionHints` is non-empty: `Python version: <value>`
-  - If empty: `No Python version pin detected.`
+  - If empty: `No Python version pin detected.` (DO NOT prefix with "Python version:").
+
+Command section content rule (hard rule):
+For each of these sections:
+- ## Install dependencies
+- ## Run / develop locally
+- ## Run tests
+- ## Lint / format
+
+Output MUST be exactly one of:
+A) One or more bullet lines of the form: "* `command` (Description.)"
+OR
+B) A single standalone line: "No explicit commands detected."
+
+Do NOT output any additional explanatory lines (including per-subcategory lines like "No explicit format commands detected.") if the section already contains at least one command bullet.
+
 The document MUST start exactly like this:
 
 # ONBOARDING.md
@@ -88,34 +156,62 @@ The document MUST start exactly like this:
 ## Overview
 Repo path: <repoPath>
 
-(Include the verbatim 'summary' from analyze_repo here if present)
-
 Continue with these headings exactly:
-## Environment setup (Include Python version here)
+## Environment setup
 ## Install dependencies
-## Run / develop locally (If commands exist; otherwise "No explicit commands detected.")
-## Run tests (If commands exist; otherwise "No explicit commands detected.")
-## Lint / format (If commands exist; otherwise "No explicit commands detected.")
+## Run / develop locally
+## Run tests
+## Lint / format
+
+Lint / format is a combined section:
+- Include any lint commands and any format commands together as bullets in the same section.
+- Do not add separate sub-headings or separate fallback sentences for lint vs format.
 
 Section routing rule (hard rule):
+- Only put venv/activation commands in Environment setup.
+- Only put package install commands in Install dependencies.
+- If a `pip install ...` command is present anywhere in extracted MCP evidence, you MUST NOT output “No explicit commands detected.”
 
-- Only put venv/activation commands in Environment setup (e.g., python -m venv, source .venv/..., activate).
-- Only put package install commands in Install dependencies (e.g., any line containing pip install, poetry install, uv pip install, conda env create).
-- If a pip install ... command is present anywhere in the extracted MCP evidence, you MUST NOT output “No explicit install commands detected.”
+## Analyzer notes
+- Include ONLY if `notes` is not empty OR notebook-centric detection applies OR frameworks are detected.
+- List notes verbatim as bullet points.
+- If notebook directories are available (analyze_repo.notebooks), add a bullet listing them (informational only).
 
-## Analyzer notes (Include ONLY if `notes` is not empty. List verbatim as bullet points.)
+Frameworks (informational only; hard formatting rule):
+- If analyze_repo.frameworks is non-empty, add exactly ONE bullet in ## Analyzer notes.
+- The bullet MUST start exactly with:
+  "* Frameworks detected (from analyzer): "
+- Then list framework names joined by ", " and end the names list with a period.
+  Example names list:
+  "Django, Wagtail."
+  "Flask."
+- Then optionally append exactly one space + a parenthesized reason:
+  " (Detected via pyproject.toml classifiers.)"
+  or
+  " (Flask support detected via pyproject.toml (Poetry) dependency key 'flask' (optional).)"
 
-## Dependency files detected (List `python.dependencyFiles[*].path`)
-## Useful configuration files (List `configurationFiles[*].path` and include their `description` if present. If SHOW_PROVENANCE is true, append (source: <path>))
-## Useful docs (List `docs[*].path` and include their `description` if present)
+Reason rule:
+- If exactly one framework is present, use its detectionReason.
+- If multiple frameworks are present and ALL have the same detectionReason, use that shared detectionReason.
+- Otherwise omit the reason entirely.
+
+Safety:
+- Do NOT print frameworks[].keySymbols or frameworks[].evidencePath.
+- Do NOT use the literal labels "source:" or "evidence:" anywhere.
+## Useful configuration files
+- List `configurationFiles[*].path` as bullets.
+- If a `description` is present on a config file, include it in parentheses after the path.
+- Do NOT print provenance unless SHOW_PROVENANCE is true.
+
+## Useful docs
+- List `docs[*].path` as bullets.
+- (Do not invent descriptions for docs.)
 
 Step 5 — Write file:
-If file writing is supported, call `write_onboarding` with:
+You MUST call `write_onboarding` to persist the changes:
 - path: "ONBOARDING.md"
 - mode: "overwrite"
 - content: (the ONBOARDING.md you just generated)
-
-Hard rule: If you are running in headless mode (e.g., --yolo or --headless), DO NOT call write_onboarding. Output the Markdown content directly.
 
 Step 6 — Token usage:
 At the end of your response, write: "Token usage: <value if available, else unknown>"

--- a/evaluation_results.log
+++ b/evaluation_results.log
@@ -1,5 +1,5 @@
 
-=== Evaluation Started: Sat Dec 27 20:44:49 GMT 2025 ===
+=== Evaluation Started: Sun Dec 28 20:24:26 GMT 2025 ===
 === Running evaluation for: searxng Paper2Code imgix-python wagtail connexion ===
 Logging to: evaluation_results.log
 
@@ -7,110 +7,117 @@ Logging to: evaluation_results.log
 YOLO mode is enabled. All tool calls will be automatically approved.
 Loaded cached credentials.
 [STARTUP] StartupProfiler.flush() called with 9 phases
-[STARTUP] Recording metric for phase: cli_startup duration: 1270.7132609999999
-[STARTUP] Recording metric for phase: load_settings duration: 2.6835149999997157
-[STARTUP] Recording metric for phase: migrate_settings duration: 1.2956720000001951
-[STARTUP] Recording metric for phase: parse_arguments duration: 20.58809999999994
-[STARTUP] Recording metric for phase: load_cli_config duration: 62.2336720000003
-[STARTUP] Recording metric for phase: initialize_app duration: 1175.6381520000004
-[STARTUP] Recording metric for phase: authenticate duration: 1106.3787730000004
-[STARTUP] Recording metric for phase: discover_tools duration: 5.35702399999991
-[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 3095.3587549999993
+[STARTUP] Recording metric for phase: cli_startup duration: 1618.0717840000002
+[STARTUP] Recording metric for phase: load_settings duration: 1.760211000000254
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.6650540000000547
+[STARTUP] Recording metric for phase: parse_arguments duration: 18.30063599999994
+[STARTUP] Recording metric for phase: load_cli_config duration: 54.90636099999983
+[STARTUP] Recording metric for phase: initialize_app duration: 1534.240377
+[STARTUP] Recording metric for phase: authenticate duration: 1466.255502
+[STARTUP] Recording metric for phase: discover_tools duration: 5.050391999999192
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 1459.1505470000002
+Okay, I will read the instructions from `.gemini/B-prompt.txt`.
+Okay, I understand. I will generate the ONBOARDING.md file. First, I'll execute `analyze_repo` and `get_run_and_test_commands` to gather the necessary data.
+Calling `get_run_and_test_commands`.
+Okay, I have both outputs. I'll now assemble the `ONBOARDING.md` content by extracting data from `analyze_repo` and `get_run_and_test_commands`. I'll start with the header and `repoPath`, then proceed section by section: "Environment setup," "Install dependencies," "Run / develop locally," "Run tests," "Lint / format," "Analyzer notes," "Dependency files detected," "Useful configuration files," and "Useful docs," ensuring all rules for content and formatting are strictly followed.
+`ONBOARDING.md` is created. Token usage: unknown.
+The `ONBOARDING.md` file has been generated and saved.
+
 Token usage: unknown
 Waiting 30 seconds for rate limits...
 === Running gemini for Paper2Code ===
 YOLO mode is enabled. All tool calls will be automatically approved.
 Loaded cached credentials.
 [STARTUP] StartupProfiler.flush() called with 9 phases
-[STARTUP] Recording metric for phase: cli_startup duration: 1070.539906
-[STARTUP] Recording metric for phase: load_settings duration: 1.9441889999998239
-[STARTUP] Recording metric for phase: migrate_settings duration: 1.0977090000001226
-[STARTUP] Recording metric for phase: parse_arguments duration: 19.023392999999942
-[STARTUP] Recording metric for phase: load_cli_config duration: 42.202495
-[STARTUP] Recording metric for phase: initialize_app duration: 998.2063540000004
-[STARTUP] Recording metric for phase: authenticate duration: 952.4577910000003
-[STARTUP] Recording metric for phase: discover_tools duration: 4.868554000000131
-[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 2077.5380579999996
+[STARTUP] Recording metric for phase: cli_startup duration: 825.9608149999999
+[STARTUP] Recording metric for phase: load_settings duration: 1.701404999999795
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.1264890000002197
+[STARTUP] Recording metric for phase: parse_arguments duration: 18.917801000000054
+[STARTUP] Recording metric for phase: load_cli_config duration: 33.49728700000014
+[STARTUP] Recording metric for phase: initialize_app duration: 759.9548840000002
+[STARTUP] Recording metric for phase: authenticate duration: 709.618539
+[STARTUP] Recording metric for phase: discover_tools duration: 3.613630999999714
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 589.2290049999997
+Okay, I will read the instructions from `.gemini/B-prompt.txt`.
+Okay, I'll execute the MCP tools, then use their output to create `ONBOARDING.md` per the specified rules, and finally write the file and report token usage.
+Okay, I'll generate `ONBOARDING.md` from the `analyze_repo` and `get_run_and_test_commands` outputs, adhering strictly to all rules: populating sections like Overview, Environment setup (handling Python versions and venv), Install dependencies, Run/develop locally, Run tests, Lint/format, Analyzer notes (for notebooks and frameworks), Dependency files, Useful config, and Useful docs. I'll omit provenance as `SHOW_PROVENANCE` is false. Then, I'll write the file and report token usage.
+`ONBOARDING.md` is done. Token usage is "unknown".
+The ONBOARDING.md file has been generated and saved.
+
 Token usage: unknown
 Waiting 30 seconds for rate limits...
 === Running gemini for imgix-python ===
 YOLO mode is enabled. All tool calls will be automatically approved.
 Loaded cached credentials.
 [STARTUP] StartupProfiler.flush() called with 9 phases
-[STARTUP] Recording metric for phase: cli_startup duration: 775.822799
-[STARTUP] Recording metric for phase: load_settings duration: 1.7735219999999572
-[STARTUP] Recording metric for phase: migrate_settings duration: 1.347950999999739
-[STARTUP] Recording metric for phase: parse_arguments duration: 18.31972599999972
-[STARTUP] Recording metric for phase: load_cli_config duration: 31.813101000000188
-[STARTUP] Recording metric for phase: initialize_app duration: 716.4379309999999
-[STARTUP] Recording metric for phase: authenticate duration: 673.0122030000002
-[STARTUP] Recording metric for phase: discover_tools duration: 4.472007999999732
-[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 617.734833
-Okay, I will read the instructions from `.gemini/B-prompt.txt`.
-Error executing tool read_file: File path '/home/rogermt/imgix-python/.gemini/B-prompt.txt' is ignored by configured ignore patterns.
-`read_file` failed; `.gemini/B-prompt.txt` is ignored. I'll re-attempt with `respect_gemini_ignore: false` to bypass ignore patterns.
-Error executing tool read_file: File path '/home/rogermt/imgix-python/.gemini/B-prompt.txt' is ignored by configured ignore patterns.
-`respect_gemini_ignore: false` isn't working for `.gemini` files. I'll `cat` the file instead via `run_shell_command` to bypass ignore patterns.
-Okay, I've read the instructions. Now to Step 1: `analyze_repo` and `get_run_and_test_commands`.
-`analyze_repo` done. Now, `get_run_and_test_commands`.
-I've run `analyze_repo` and `get_run_and_test_commands`. Now, I'll generate `ONBOARDING.md` following the rules from `.gemini/B-prompt.txt`. My plan includes initializing the document, populating sections for environment setup, dependencies, local development, testing, linting/formatting, analyzer notes, dependency files, configuration files, and documentation. Finally, I'll use `write_onboarding` and report token usage. I will use the extracted data and `SHOW_PROVENANCE = False` to construct the document.
-`ONBOARDING.md` created. Task finished.
-This task is complete.
+[STARTUP] Recording metric for phase: cli_startup duration: 1097.59656
+[STARTUP] Recording metric for phase: load_settings duration: 1.6510800000000927
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.0125920000000406
+[STARTUP] Recording metric for phase: parse_arguments duration: 17.520680000000084
+[STARTUP] Recording metric for phase: load_cli_config duration: 37.39631199999985
+[STARTUP] Recording metric for phase: initialize_app duration: 1032.3657129999997
+[STARTUP] Recording metric for phase: authenticate duration: 985.5148039999999
+[STARTUP] Recording metric for phase: discover_tools duration: 3.668401999999787
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 735.0318040000002
+Okay, I have reviewed the project setup. I'm ready for your first command.
+I will now proceed with the following steps to generate the `ONBOARDING.md` file:
 
+1.  Call `analyze_repo` to gather repository information.
+2.  Call `get_run_and_test_commands` to identify run and test commands.
+3.  Process the output from both tools according to the strict grounding rules.
+4.  Generate the `ONBOARDING.md` content.
+5.  Write the generated content to `ONBOARDING.md` using `write_onboarding`.
+`analyze_repo` is complete. Next, `get_run_and_test_commands`.
+I've retrieved data from `analyze_repo` and `get_run_and_test_commands`. My next step is to assemble the `ONBOARDING.md` file by meticulously extracting and formatting this information according to the specified grounding rules for each section: Overview, Environment setup, Install dependencies, Run/develop locally, Run tests, Lint/format, Analyzer notes, Dependency files, Useful configuration files, and Useful docs. I will prioritize `make install` if available for dependencies and include a generic venv setup if no Python version or venv commands are detected. Framework and notebook information will populate Analyzer notes if present. Finally, I will ensure proper command and file formatting throughout the document.
+
+I will now construct the `ONBOARDING.md` content.
+`ONBOARDING.md` is done. Token usage is unknown.
 Token usage: unknown
 Waiting 30 seconds for rate limits...
 === Running gemini for wagtail ===
 YOLO mode is enabled. All tool calls will be automatically approved.
 Loaded cached credentials.
 [STARTUP] StartupProfiler.flush() called with 9 phases
-[STARTUP] Recording metric for phase: cli_startup duration: 818.6458259999999
-[STARTUP] Recording metric for phase: load_settings duration: 2.032923999999639
-[STARTUP] Recording metric for phase: migrate_settings duration: 1.4173209999999017
-[STARTUP] Recording metric for phase: parse_arguments duration: 20.242791000000125
-[STARTUP] Recording metric for phase: load_cli_config duration: 55.11002899999994
-[STARTUP] Recording metric for phase: initialize_app duration: 732.9202650000002
-[STARTUP] Recording metric for phase: authenticate duration: 655.9455800000001
-[STARTUP] Recording metric for phase: discover_tools duration: 3.3637079999998605
-[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 589.9423449999999
+[STARTUP] Recording metric for phase: cli_startup duration: 832.2727869999999
+[STARTUP] Recording metric for phase: load_settings duration: 2.0640260000000126
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.2721879999999146
+[STARTUP] Recording metric for phase: parse_arguments duration: 21.164260000000013
+[STARTUP] Recording metric for phase: load_cli_config duration: 64.41384299999982
+[STARTUP] Recording metric for phase: initialize_app duration: 734.9597469999999
+[STARTUP] Recording metric for phase: authenticate duration: 686.8582539999998
+[STARTUP] Recording metric for phase: discover_tools duration: 4.0995279999997365
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 543.6345350000001
 Okay, I will read the instructions from `.gemini/B-prompt.txt`.
-Okay, I'll call `analyze_repo` now.
-Okay, `get_run_and_test_commands` next.
-Okay, I'll build `ONBOARDING.md` using the `analyze_repo` and `get_run_and_test_commands` outputs. I'll include `repoPath`, Python version (detecting "No Python version pin detected" if hints are absent), and environment setup (generic venv if needed). Dependencies will be handled, prioritizing `make install` then `installInstructions`, otherwise "No explicit commands detected." The same "No explicit commands detected" rule applies to local run/develop, test, lint, and format sections if no commands are found. Analyzer notes will include general notes and notebook-centric information if applicable. Finally, I'll list dependency files, configuration files with descriptions, and document paths. `SHOW_PROVENANCE` will be false.
-I'll now create `ONBOARDING.md` using the provided content.
-`ONBOARDING.md` created. Updating todo list.
-Done. Token usage: unknown.
+Okay, I'll generate the `ONBOARDING.md` file. First, I'll call `analyze_repo` and `get_run_and_test_commands` to gather the necessary information. Then, I'll format that data according to the specified grounding rules before writing the file.
+Okay, `analyze_repo` is done. Next, `get_run_and_test_commands`.
+Okay, I have both `analyze_repo` and `get_run_and_test_commands` outputs. I'll now generate `ONBOARDING.md` by initializing it with the overview, then populate sections for environment setup (including Python version and venv), dependency installation (prioritizing `make install`), local development, testing, linting/formatting, analyzer notes (frameworks and general notes), dependency files, configuration files, and documentation. Finally, I'll write the file using `write_onboarding` and report token usage.
+Alright, I'll build `ONBOARDING.md`. I'll start with the repo path, then state "No Python version pin detected" for environment setup, followed by generic venv instructions. For dependencies, I'll use `pip install .`. Development, test, lint, and format commands will come directly from their respective script sections. Analyzer notes will include the "docs truncated" message and the "Django, Wagtail" framework detection with its shared reason. Finally, I'll list dependency files, configuration files, and documentation files, then write the complete content.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+Right, back to the ONBOARDING.md.
+I'll now write the `ONBOARDING.md` file using the generated content, which includes the project overview, environment setup, installation, development, testing, linting/formatting commands, analyzer notes, dependency files, and useful configuration and documentation files.
+`ONBOARDING.md` is done. Reporting token usage now.
+Token usage: unknown
 Waiting 30 seconds for rate limits...
 === Running gemini for connexion ===
 YOLO mode is enabled. All tool calls will be automatically approved.
 Loaded cached credentials.
 [STARTUP] StartupProfiler.flush() called with 9 phases
-[STARTUP] Recording metric for phase: cli_startup duration: 755.445804
-[STARTUP] Recording metric for phase: load_settings duration: 1.6847760000000562
-[STARTUP] Recording metric for phase: migrate_settings duration: 1.089368000000377
-[STARTUP] Recording metric for phase: parse_arguments duration: 16.28722800000014
-[STARTUP] Recording metric for phase: load_cli_config duration: 33.84338099999968
-[STARTUP] Recording metric for phase: initialize_app duration: 695.9524349999997
-[STARTUP] Recording metric for phase: authenticate duration: 651.600852
-[STARTUP] Recording metric for phase: discover_tools duration: 3.183324999999968
-[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 509.955097
-Okay, I will read the instructions from `.gemini/B-prompt.txt`.
-Okay, instructions from `.gemini/B-prompt.txt` read. Step 1: Execute `analyze_repo` and `get_run_and_test_commands`.
-I've retrieved analysis and command data. Now, I'll generate the `ONBOARDING.md` content based on the provided rules.
-
-The document will include sections for:
-*   **Overview**: Repo path.
-*   **Environment setup**: Python version (3.12) and a generic venv creation/activation snippet, as no explicit setup was found.
-*   **Install dependencies**: `pip install .` as the primary install command.
-*   **Run / develop locally**: "No explicit commands detected."
-*   **Run tests**: `tox`.
-*   **Lint / format**: `tox -e flake8`.
-*   **Analyzer notes**: Truncated docs list.
-*   **Dependency files detected**: Listed `pyproject.toml` and `requirements.txt` files.
-*   **Useful configuration files**: Listed `.pre-commit-config.yaml`, `tox.ini`, and GitHub workflow files with descriptions.
-*   **Useful docs**: Listed the first 10 document paths.
-
-Finally, I will use `write_onboarding` to create the `ONBOARDING.md` file with this generated content.
-`ONBOARDING.md` is generated. Token usage next.
+[STARTUP] Recording metric for phase: cli_startup duration: 822.8688859999997
+[STARTUP] Recording metric for phase: load_settings duration: 1.8452400000001035
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.1609090000001743
+[STARTUP] Recording metric for phase: parse_arguments duration: 21.437173000000257
+[STARTUP] Recording metric for phase: load_cli_config duration: 39.512944999999945
+[STARTUP] Recording metric for phase: initialize_app duration: 745.479734
+[STARTUP] Recording metric for phase: authenticate duration: 704.2200080000002
+[STARTUP] Recording metric for phase: discover_tools duration: 3.5191060000001926
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 531.672857
 Token usage: unknown
 Waiting 30 seconds for rate limits...
 
@@ -128,7 +135,7 @@ Python version: 3.14
 * `source .venv/bin/activate` (Activate virtual environment.)
 
 ## Install dependencies
-* `make install` (No description.)
+* `make install` (Install dependencies via Makefile target.)
 
 ## Run / develop locally
 * `make run` (Run the application via Makefile target.)
@@ -143,10 +150,10 @@ Python version: 3.14
 * docs list truncated to 10 entries (total=174)
 
 ## Dependency files detected
-* requirements.txt
-* requirements-dev.txt
-* requirements-server.txt
-* setup.py
+* requirements.txt (Python dependency manifest.)
+* requirements-dev.txt (Python dependency manifest.)
+* requirements-server.txt (Python dependency manifest.)
+* setup.py (Packaging/build configuration (setuptools).)
 
 ## Useful configuration files
 * Makefile (Primary task runner for development and build orchestration.)
@@ -185,7 +192,7 @@ No Python version pin detected.
 * `source .venv/bin/activate` (Activate virtual environment.)
 
 ## Install dependencies
-* `pip install -r requirements.txt` (Install project dependencies.)
+* `pip install -r requirements.txt` (Install dependencies.)
 
 ## Run / develop locally
 * `bash scripts/run.sh` (Run repo script entrypoint.)
@@ -205,7 +212,7 @@ No explicit commands detected.
 * Notebooks found in: notebooks/examples/
 
 ## Dependency files detected
-* requirements.txt
+* requirements.txt (Python dependency manifest.)
 
 ## Useful configuration files
 * .pre-commit-config.yaml (Pre-commit config for cleaning Jupyter notebooks (e.g. stripping outputs) for cleaner diffs.)
@@ -216,7 +223,6 @@ No explicit commands detected.
 * README.md
 * data/paper2code/README.md
 * notebooks/README.md
-
 --- Validating ONBOARDING.md for Paper2Code ---
 Validation passed for ONBOARDING.md.
 
@@ -234,7 +240,7 @@ No Python version pin detected.
 * `source .venv/bin/activate` (Activate virtual environment.)
 
 ## Install dependencies
-* `pip install -e .` (Install package in editable mode.)
+* `pip install -e .` (Install the project in editable mode.)
 
 ## Run / develop locally
 No explicit commands detected.
@@ -246,8 +252,8 @@ No explicit commands detected.
 * `tox -e flake8` (Run flake8 linting via tox.)
 
 ## Dependency files detected
-* setup.cfg
-* setup.py
+* setup.cfg (Packaging/build configuration (setuptools).)
+* setup.py (Packaging/build configuration (setuptools).)
 
 ## Useful configuration files
 * tox.ini (Test environment orchestrator (tox).)
@@ -275,28 +281,29 @@ No Python version pin detected.
 * `source .venv/bin/activate` (Activate virtual environment.)
 
 ## Install dependencies
-* `pip install .` (Install the project in editable mode.)
+* `pip install .` (Install the package in editable mode.)
 
 ## Run / develop locally
-* `bash scripts/fetch-translations.sh` (Delete old translation files (except "en" which is the source translation))
-* `bash scripts/rebuild-translation-sources.sh` (Delete old translation sources)
+* `bash scripts/fetch-translations.sh` (Delete old translation files (except "en" which is the source translation).)
+* `bash scripts/rebuild-translation-sources.sh` (Delete old translation sources.)
 
 ## Run tests
 * `make test` (Run the test suite via Makefile target.)
 * `bash scripts/latest.sh` (Run repo script entrypoint.)
-* `tox` (Run tests via tox)
+* `tox` (Run tests via tox.)
 
 ## Lint / format
-* `make lint` (Lint code via Makefile target.)
+* `make lint` (Run linting via Makefile target.)
 * `make format` (Run formatting via Makefile target.)
 
 ## Analyzer notes
+* Frameworks detected (from analyzer): Django, Wagtail. (Detected via pyproject.toml classifiers.)
 * docs list truncated to 10 entries (total=366)
 
 ## Dependency files detected
-* pyproject.toml
-* wagtail/project_template/requirements.txt
-* setup.py
+* pyproject.toml (Project configuration and dependency management (PEP 518/621).)
+* wagtail/project_template/requirements.txt (Python dependency manifest.)
+* setup.py (Packaging/build configuration (setuptools).)
 
 ## Useful configuration files
 * Makefile (Primary task runner for development and build orchestration.)
@@ -334,7 +341,7 @@ Python version: 3.12
 * `source .venv/bin/activate` (Activate virtual environment.)
 
 ## Install dependencies
-* `pip install .` (Install project dependencies.)
+* `pip install .` (Install project in editable mode.)
 
 ## Run / develop locally
 No explicit commands detected.
@@ -346,13 +353,14 @@ No explicit commands detected.
 * `tox -e flake8` (Run flake8 linting via tox.)
 
 ## Analyzer notes
+* Frameworks detected (from analyzer): Flask. (Flask support detected via pyproject.toml (Poetry) dependency key 'flask' (optional).)
 * docs list truncated to 10 entries (total=34)
 
 ## Dependency files detected
-* pyproject.toml
-* examples/frameworks/requirements.txt
-* examples/jwt/requirements.txt
-* examples/sqlalchemy/requirements.txt
+* pyproject.toml (Project configuration and dependency management (PEP 518/621).)
+* examples/frameworks/requirements.txt (Python dependency manifest.)
+* examples/jwt/requirements.txt (Python dependency manifest.)
+* examples/sqlalchemy/requirements.txt (Python dependency manifest.)
 
 ## Useful configuration files
 * .pre-commit-config.yaml (Pre-commit hooks configuration (code quality automation).)
@@ -371,7 +379,6 @@ No explicit commands detected.
 * docs/lifespan.rst
 * docs/middleware.rst
 * docs/quickstart.rst
-
 --- Validating ONBOARDING.md for connexion ---
 warning: No `requires-python` value found in the workspace. Defaulting to `>=3.13`.
 Validation passed for ONBOARDING.md.

--- a/src/mcp_repo_onboarding/analysis/core.py
+++ b/src/mcp_repo_onboarding/analysis/core.py
@@ -32,6 +32,7 @@ from .extractors import (
     extract_shell_scripts,
     extract_tox_commands,
 )
+from .frameworks import detect_frameworks_from_pyproject
 from .notebook_hygiene import precommit_has_notebook_hygiene
 from .prioritization import get_config_priority, get_dep_priority, get_doc_priority
 from .scanning import scan_repo_files
@@ -339,6 +340,9 @@ def analyze_repo(repo_path: str, max_files: int = DEFAULT_MAX_FILES) -> RepoAnal
     # 6. Extract Scripts
     scripts = _aggregate_scripts(root, configs, all_files)
 
+    # Framework detection (cheap, deterministic): pyproject classifiers
+    frameworks = detect_frameworks_from_pyproject(root)
+
     # 7. Infer Python Env
     python_info = _infer_python_environment(root, py_files, dep_files)
 
@@ -368,6 +372,7 @@ def analyze_repo(repo_path: str, max_files: int = DEFAULT_MAX_FILES) -> RepoAnal
         docs=docs,
         configurationFiles=configs,
         scripts=scripts,
+        frameworks=frameworks,
         notes=notes,
         python=python_info,
         notebooks=notebooks_field,

--- a/src/mcp_repo_onboarding/analysis/frameworks.py
+++ b/src/mcp_repo_onboarding/analysis/frameworks.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from ..schema import FrameworkInfo
+
+_MAX_BYTES = 256_000  # size cap for deterministic/cheap reads
+
+
+def detect_frameworks_from_pyproject(
+    repo_root: Path, rel_path: str = "pyproject.toml"
+) -> list[FrameworkInfo]:
+    """
+    Detect frameworks using pyproject.toml metadata.
+
+    Deterministic:
+    - size-capped read
+    - parse via tomllib
+    - prefers explicit framework classifiers when available
+    - otherwise uses dependency presence as a conservative hint (e.g. Poetry deps)
+    """
+    root = repo_root.resolve()
+    p = (root / rel_path).resolve()
+    try:
+        p.relative_to(root)
+    except Exception:
+        return []
+
+    try:
+        if not p.is_file():
+            return []
+        if p.stat().st_size > _MAX_BYTES:
+            return []
+        raw = p.read_text(encoding="utf-8", errors="ignore")
+        data: dict[str, Any] = tomllib.loads(raw)
+    except OSError:
+        return []
+    except Exception:
+        # tomllib parse errors should not crash analysis
+        return []
+
+    # --- Collect classifiers from both PEP 621 and Poetry ---
+    cls: list[str] = []
+
+    project = data.get("project") or {}
+    project_classifiers = project.get("classifiers") or []
+    if isinstance(project_classifiers, list):
+        cls.extend([c for c in project_classifiers if isinstance(c, str)])
+
+    tool = data.get("tool") or {}
+    poetry = tool.get("poetry") or {}
+    poetry_classifiers = poetry.get("classifiers") or []
+    if isinstance(poetry_classifiers, list):
+        cls.extend([c for c in poetry_classifiers if isinstance(c, str)])
+
+    found: dict[str, FrameworkInfo] = {}
+
+    def _has(prefix: str) -> bool:
+        return any(c.strip() == prefix or c.strip().startswith(prefix + " ::") for c in cls)
+
+    # Minimal, conservative detections from explicit classifiers
+    if _has("Framework :: Django"):
+        found["Django"] = FrameworkInfo(
+            name="Django",
+            detectionReason="Detected via pyproject.toml classifiers",
+            keySymbols=["Framework :: Django"],
+            evidencePath=rel_path,
+        )
+
+    if _has("Framework :: Wagtail"):
+        found["Wagtail"] = FrameworkInfo(
+            name="Wagtail",
+            detectionReason="Detected via pyproject.toml classifiers",
+            keySymbols=["Framework :: Wagtail"],
+            evidencePath=rel_path,
+        )
+
+    def _poetry_dep_is_optional(dep_val: Any) -> bool:
+        """
+        Poetry dependency values can be:
+        - string version (e.g. "^3.9")
+        - dict/table (e.g. {version=">=2", optional=true, extras=[...]} )
+        We only treat it as optional when explicitly declared optional=true.
+        """
+        return isinstance(dep_val, dict) and bool(dep_val.get("optional") is True)
+
+    # --- If classifiers did not cover everything, fall back to dependency presence ---
+    # Poetry deps: [tool.poetry.dependencies] is a table/map. Connexion declares flask as optional extra there.
+    poetry_deps = poetry.get("dependencies") or {}
+    if isinstance(poetry_deps, dict):
+        dep_keys = {str(k).lower() for k in poetry_deps}
+
+        # Flask support (often optional, but still a valid "framework present" hint)
+        if "flask" in dep_keys and "Flask" not in found:
+            flask_optional = _poetry_dep_is_optional(poetry_deps.get("flask"))
+            found["Flask"] = FrameworkInfo(
+                name="Flask",
+                detectionReason=(
+                    "Flask support detected via pyproject.toml (Poetry) dependency key 'flask' (optional)."
+                    if flask_optional
+                    else "Detected via pyproject.toml (Poetry) dependency key 'flask'"
+                ),
+                keySymbols=["tool.poetry.dependencies.flask"],
+                evidencePath=rel_path,
+            )
+
+        # Django dependency (for Poetry-format projects)
+        if "django" in dep_keys and "Django" not in found:
+            django_optional = _poetry_dep_is_optional(poetry_deps.get("django"))
+            found["Django"] = FrameworkInfo(
+                name="Django",
+                detectionReason=(
+                    "Django support detected via pyproject.toml (Poetry) dependency key 'django' (optional)."
+                    if django_optional
+                    else "Detected via pyproject.toml (Poetry) dependency key 'django'"
+                ),
+                keySymbols=["tool.poetry.dependencies.django"],
+                evidencePath=rel_path,
+            )
+
+        # FastAPI dependency (Poetry-format projects)
+        if "fastapi" in dep_keys and "FastAPI" not in found:
+            fastapi_optional = _poetry_dep_is_optional(poetry_deps.get("fastapi"))
+            found["FastAPI"] = FrameworkInfo(
+                name="FastAPI",
+                detectionReason=(
+                    "FastAPI support detected via pyproject.toml (Poetry) dependency key 'fastapi' (optional)."
+                    if fastapi_optional
+                    else "Detected via pyproject.toml (Poetry) dependency key 'fastapi'"
+                ),
+                keySymbols=["tool.poetry.dependencies.fastapi"],
+                evidencePath=rel_path,
+            )
+
+    # Deterministic output order
+    return [found[k] for k in sorted(found.keys())]

--- a/src/mcp_repo_onboarding/describers.py
+++ b/src/mcp_repo_onboarding/describers.py
@@ -127,6 +127,22 @@ class MakeRunDescriber(MetadataDescriber):
         return target
 
 
+class MakeInstallDescriber(MetadataDescriber):
+    """Describer for 'make install' command."""
+
+    def describe(self, target: CommandInfo) -> CommandInfo:
+        target.description = "Install dependencies via Makefile target."
+        return target
+
+
+class MakeLintDescriber(MetadataDescriber):
+    """Describer for 'make lint' command."""
+
+    def describe(self, target: CommandInfo) -> CommandInfo:
+        target.description = "Run linting via Makefile target."
+        return target
+
+
 class ToxDescriber(MetadataDescriber):
     """Describer for 'tox' command."""
 
@@ -173,6 +189,8 @@ COMMAND_DESCRIBER_REGISTRY: dict[str, MetadataDescriber] = {
     "make test": MakeTestDescriber(),
     "make format": MakeFormatDescriber(),
     "make run": MakeRunDescriber(),
+    "make install": MakeInstallDescriber(),
+    "make lint": MakeLintDescriber(),
     "tox": ToxDescriber(),
     "tox -e": ToxEnvDescriber(),  # Prefix for tox environments
     "bash scripts/": BashScriptDescriber(),  # Prefix for shell scripts

--- a/src/mcp_repo_onboarding/schema.py
+++ b/src/mcp_repo_onboarding/schema.py
@@ -60,6 +60,8 @@ class FrameworkInfo(BaseModel):
 
     name: str
     detectionReason: str
+    keySymbols: list[str] = Field(default_factory=list)
+    evidencePath: str | None = None
 
 
 class TestSetup(BaseModel):

--- a/tests/fixtures/fw-poetry-flask/pyproject.toml
+++ b/tests/fixtures/fw-poetry-flask/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.poetry]
+name = "fw-poetry-flask"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+flask = "^2.0"

--- a/tests/fixtures/test_makefile_command_descriptions.py
+++ b/tests/fixtures/test_makefile_command_descriptions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from mcp_repo_onboarding.analysis import analyze_repo
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_make_install_has_description(temp_repo: Callable[[str], Path]) -> None:
+    repo = temp_repo("make-install-desc")
+    _write(repo / "pyproject.toml", '[project]\nname="x"\nversion="0.0.0"\n')
+
+    _write(repo / "Makefile", "install:\n\t@echo install\n")
+    a = analyze_repo(repo_path=str(repo))
+
+    install_cmds = [c for c in a.scripts.install if c.command == "make install"]
+    assert install_cmds, "Expected make install command to be detected"
+    assert install_cmds[0].description == "Install dependencies via Makefile target."
+
+
+def test_make_lint_has_description(temp_repo: Callable[[str], Path]) -> None:
+    repo = temp_repo("make-lint-desc")
+    _write(repo / "pyproject.toml", '[project]\nname="x"\nversion="0.0.0"\n')
+
+    _write(repo / "Makefile", "lint:\n\t@echo lint\n")
+    a = analyze_repo(repo_path=str(repo))
+
+    lint_cmds = [c for c in a.scripts.lint if c.command == "make lint"]
+    assert lint_cmds, "Expected make lint command to be detected"
+    assert lint_cmds[0].description == "Run linting via Makefile target."
+
+
+def test_make_format_has_description(temp_repo: Callable[[str], Path]) -> None:
+    repo = temp_repo("make-format-desc")
+    _write(repo / "pyproject.toml", '[project]\nname="x"\nversion="0.0.0"\n')
+
+    _write(repo / "Makefile", "format:\n\t@echo format\n")
+    a = analyze_repo(repo_path=str(repo))
+
+    fmt_cmds = [c for c in a.scripts.format if c.command == "make format"]
+    assert fmt_cmds, "Expected make format command to be detected"
+    assert fmt_cmds[0].description == "Run formatting via Makefile target."

--- a/tests/test_frameworks_from_pyproject.py
+++ b/tests/test_frameworks_from_pyproject.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from mcp_repo_onboarding.analysis import analyze_repo
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_detects_django_and_wagtail_from_classifiers(temp_repo: Callable[[str], Path]) -> None:
+    repo = temp_repo("fw-pyproject-classifiers")
+
+    _write(
+        repo / "pyproject.toml",
+        """
+[project]
+name = "x"
+version = "0.0.0"
+classifiers = [
+  "Framework :: Django",
+  "Framework :: Wagtail",
+]
+""".lstrip(),
+    )
+
+    a = analyze_repo(repo_path=str(repo))
+    fw = {f.name: f for f in a.frameworks}
+
+    assert "Django" in fw
+    assert fw["Django"].evidencePath == "pyproject.toml"
+    assert fw["Django"].keySymbols == ["Framework :: Django"]
+
+    assert "Wagtail" in fw
+    assert fw["Wagtail"].evidencePath == "pyproject.toml"
+    assert fw["Wagtail"].keySymbols == ["Framework :: Wagtail"]

--- a/tests/test_frameworks_poetry_pyproject.py
+++ b/tests/test_frameworks_poetry_pyproject.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from mcp_repo_onboarding.analysis import analyze_repo
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_detects_flask_from_poetry_dependencies(temp_repo: Callable[[str], Path]) -> None:
+    repo = temp_repo("fw-poetry-flask")
+    _write(
+        repo / "pyproject.toml",
+        """
+[tool.poetry]
+name = "connexion"
+version = "0.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+flask = { version = ">= 2.2", extras = ["async"], optional = true }
+
+[build-system]
+requires = ["poetry-core>=1.2.0"]
+build-backend = "poetry.core.masonry.api"
+""".lstrip(),
+    )
+
+    a = analyze_repo(repo_path=str(repo))
+    fw = {f.name: f for f in a.frameworks}
+
+    assert "Flask" in fw
+    assert fw["Flask"].evidencePath == "pyproject.toml"
+    assert fw["Flask"].keySymbols == ["tool.poetry.dependencies.flask"]
+    # optional=true in Poetry deps should be reflected in the detection reason (neutral, non-prescriptive)
+    reason = fw["Flask"].detectionReason
+    assert "pyproject.toml" in reason
+    assert "Poetry" in reason
+    assert "dependency key 'flask'" in reason
+    assert "(optional)" in reason

--- a/tests/test_makefile_command_descriptions.py
+++ b/tests/test_makefile_command_descriptions.py
@@ -1,0 +1,26 @@
+from collections.abc import Callable
+from pathlib import Path
+
+from mcp_repo_onboarding.analysis import analyze_repo
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_make_install_has_description(temp_repo: Callable[[str], Path]) -> None:
+    repo = temp_repo("makefile-with-recipes")
+    _write(
+        repo / "Makefile",
+        """
+install:
+\t@echo "Installing dependencies..."
+\tpython setup.py install
+
+.PHONY: install
+""".lstrip(),
+    )
+    a = analyze_repo(repo_path=str(repo))
+    assert a.scripts.install[0].description is not None
+    assert len(a.scripts.install[0].description) > 0


### PR DESCRIPTION
# Feature: Narrow evidence strings (“key symbols”) for framework/entrypoint detections

## Summary

This PR implements deterministic framework detection strategies and enhances the robustness of command description extraction. It introduces the concept of `keySymbols` in the schema to provide precise evidence for detected frameworks (e.g., specific classifiers or dependency keys) without cluttering the user-facing `ONBOARDING.md`. Additionally, it ensures all Makefile commands have descriptions to meet strict output formatting rules.

## Related issues

- Closes #23 

## Changes

- [x] Code changes in `src/mcp_repo_onboarding/analysis/` (`frameworks.py`, `core.py`, `extractors.py`) and `schema.py`.
- [x] Tests added/updated in `tests/` (`test_frameworks_*.py`, `test_makefile_command_descriptions.py`).
- [x] Docs updated (`docs/evaluation/B-prompt.txt`, `docs/design/EXTRACT_OUTPUT_RULES.md`).

### Key changes

- **Schema Update**: Added `keySymbols` (list[str]) and `evidencePath` (str) to `FrameworkInfo` to track exactly *why* a framework was detected.
- **Framework Detection**: Added `src/mcp_repo_onboarding/analysis/frameworks.py` implementing deterministic detection via `pyproject.toml`.
  - Supports PEP 621 `project.classifiers`.
  - Supports `tool.poetry.classifiers`.
  - Supports `tool.poetry.dependencies` checks (Flask, Django, FastAPI), including optional dependencies.
- **Makefile Robustness**: Updated `extractors.py` and `describers.py` to ensure every Makefile target has a description (via new describers or fallback), preventing “bare” bullets in final output.
- **Prompt Updates**: Updated `B-prompt.txt` to instruct the LLM to present framework names and reasons, but omit internal `keySymbols` and `evidencePath` from final prose.

## How to test

Run the full test suite (including new framework and Makefile tests):

```
uv run pytest
```

Specific new tests:

```
uv run pytest tests/test_frameworks_from_pyproject.py
uv run pytest tests/test_frameworks_poetry_pyproject.py
uv run pytest tests/test_makefile_command_descriptions.py
```

Tested on fixtures:

- `fw-pyproject-classifiers` (Django/Wagtail detection via classifiers)
- `fw-poetry-flask` (Flask detection via Poetry dependencies)
- `makefile-with-recipes` (Fallback descriptions for `make install`)

## Checklist

- [x] I’ve read the scope and non‑goals in the README/design docs.
- [x] My changes stay within the project’s responsibilities (env/deps/run/test).
- [x] `uv run pytest` passes locally.
- [x] I’ve added or updated tests for any new behavior.

---

If you want, I can also normalize heading levels, rewrite for clarity, or convert this into a PR description template.