### PR TITLE
Feat/add gemini extension 75

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -2,12 +2,14 @@
   "name": "repo-onboarding",
   "version": "0.1.0",
   "description": "Analyzes a Python repository to generate ONBOARDING.md.",
-  "mcpServer": {
-    "command": "uv",
-    "args": ["run", "mcp-repo-onboarding"],
-    "cwd": "./",
-    "env": {
-      "REPO_ROOT": "."
+  "mcpServers": {
+    "repo-onboarding": {
+      "command": "uv",
+      "args": ["run", "mcp-repo-onboarding"],
+      "cwd": "./",
+      "env": {
+        "REPO_ROOT": "."
+      }
     }
   }
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,13 @@
+{
+  "name": "repo-onboarding",
+  "version": "0.1.0",
+  "description": "Analyzes a Python repository to generate ONBOARDING.md.",
+  "mcpServer": {
+    "command": "uv",
+    "args": ["run", "mcp-repo-onboarding"],
+    "cwd": "./",
+    "env": {
+      "REPO_ROOT": "."
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ packages = ["src/mcp_repo_onboarding"]
 [tool.hatch.build.targets.sdist]
 include = [
     "src/mcp_repo_onboarding/mcp_prompt.txt",
+    "gemini-extension.json",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
Add Gemini extension configuration file to enable MCP server integration.

## Changes
- Create `gemini-extension.json` with correct `mcpServers` schema
- Define nested `repo-onboarding` server config with command and environment
- Include in sdist build artifacts via `pyproject.toml`

## Verification
- All 150 tests pass
- Linting passes
- ✓ Extension installed: `repo-onboarding (v0.1.0) - active (up to date)`
- ✓ Command available: `/generate_onboarding [MCP]`

Closes #75
