### PR TITLE
refactor(#78): Config cleanup — single source of truth for file class…

### DIFF
--- a/evaluation_results.log
+++ b/evaluation_results.log
@@ -1,22 +1,138 @@
 
-=== Running evaluation for: Paper2Code ===
+=== Evaluation Started: Thu Jan  1 14:07:06 GMT 2026 ===
+=== Running evaluation for: searxng Paper2Code imgix-python wagtail connexion ===
 Logging to: evaluation_results.log
 
+=== Running gemini for searxng ===
+YOLO mode is enabled. All tool calls will be automatically approved.
+Loaded cached credentials.
+[STARTUP] StartupProfiler.flush() called with 9 phases
+[STARTUP] Recording metric for phase: cli_startup duration: 1433.624488
+[STARTUP] Recording metric for phase: load_settings duration: 2.9591519999999036
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.8889859999999317
+[STARTUP] Recording metric for phase: parse_arguments duration: 25.618675000000167
+[STARTUP] Recording metric for phase: load_cli_config duration: 72.97904200000039
+[STARTUP] Recording metric for phase: initialize_app duration: 1321.8782659999997
+[STARTUP] Recording metric for phase: authenticate duration: 1257.8263109999998
+[STARTUP] Recording metric for phase: discover_tools duration: 5.915118999999777
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 849.6554320000005
+Token usage: unknown
+Waiting 30 seconds for rate limits...
 === Running gemini for Paper2Code ===
 YOLO mode is enabled. All tool calls will be automatically approved.
 Loaded cached credentials.
 [STARTUP] StartupProfiler.flush() called with 9 phases
-[STARTUP] Recording metric for phase: cli_startup duration: 1225.434518
-[STARTUP] Recording metric for phase: load_settings duration: 1.7123139999998784
-[STARTUP] Recording metric for phase: migrate_settings duration: 1.217453000000205
-[STARTUP] Recording metric for phase: parse_arguments duration: 16.90113999999994
-[STARTUP] Recording metric for phase: load_cli_config duration: 31.921629999999823
-[STARTUP] Recording metric for phase: initialize_app duration: 1166.9956069999998
-[STARTUP] Recording metric for phase: authenticate duration: 1109.048909
-[STARTUP] Recording metric for phase: discover_tools duration: 3.4725530000000617
-[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 565.0559590000003
+[STARTUP] Recording metric for phase: cli_startup duration: 1015.0168389999999
+[STARTUP] Recording metric for phase: load_settings duration: 2.072747000000163
+[STARTUP] Recording metric for phase: migrate_settings duration: 2.1053389999997307
+[STARTUP] Recording metric for phase: parse_arguments duration: 21.837721999999758
+[STARTUP] Recording metric for phase: load_cli_config duration: 56.866161999999804
+[STARTUP] Recording metric for phase: initialize_app duration: 924.2147439999994
+[STARTUP] Recording metric for phase: authenticate duration: 804.8758240000002
+[STARTUP] Recording metric for phase: discover_tools duration: 7.496979999999894
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 2479.5311599999995
 Token usage: unknown
 Waiting 30 seconds for rate limits...
+=== Running gemini for imgix-python ===
+YOLO mode is enabled. All tool calls will be automatically approved.
+Loaded cached credentials.
+[STARTUP] StartupProfiler.flush() called with 9 phases
+[STARTUP] Recording metric for phase: cli_startup duration: 1044.4897800000003
+[STARTUP] Recording metric for phase: load_settings duration: 2.289400999999998
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.4093880000000354
+[STARTUP] Recording metric for phase: parse_arguments duration: 21.902262999999948
+[STARTUP] Recording metric for phase: load_cli_config duration: 42.95405500000015
+[STARTUP] Recording metric for phase: initialize_app duration: 967.2656929999998
+[STARTUP] Recording metric for phase: authenticate duration: 795.9488409999999
+[STARTUP] Recording metric for phase: discover_tools duration: 6.901436000000103
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 1546.8752999999997
+Token usage: unknown
+Waiting 30 seconds for rate limits...
+=== Running gemini for wagtail ===
+YOLO mode is enabled. All tool calls will be automatically approved.
+Loaded cached credentials.
+[STARTUP] StartupProfiler.flush() called with 9 phases
+[STARTUP] Recording metric for phase: cli_startup duration: 1073.07233
+[STARTUP] Recording metric for phase: load_settings duration: 2.901274000000285
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.6585519999998724
+[STARTUP] Recording metric for phase: parse_arguments duration: 44.76086400000031
+[STARTUP] Recording metric for phase: load_cli_config duration: 74.30294800000001
+[STARTUP] Recording metric for phase: initialize_app duration: 939.681165
+[STARTUP] Recording metric for phase: authenticate duration: 793.5254569999997
+[STARTUP] Recording metric for phase: discover_tools duration: 10.697440999999344
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 1220.9360860000006
+Token usage: unknown
+Waiting 30 seconds for rate limits...
+=== Running gemini for connexion ===
+YOLO mode is enabled. All tool calls will be automatically approved.
+Loaded cached credentials.
+[STARTUP] StartupProfiler.flush() called with 9 phases
+[STARTUP] Recording metric for phase: cli_startup duration: 896.1135290000002
+[STARTUP] Recording metric for phase: load_settings duration: 2.206047000000126
+[STARTUP] Recording metric for phase: migrate_settings duration: 1.3341209999998682
+[STARTUP] Recording metric for phase: parse_arguments duration: 20.82672199999979
+[STARTUP] Recording metric for phase: load_cli_config duration: 44.02371600000015
+[STARTUP] Recording metric for phase: initialize_app duration: 820.6295009999999
+[STARTUP] Recording metric for phase: authenticate duration: 751.4521909999999
+[STARTUP] Recording metric for phase: discover_tools duration: 5.155612999999903
+[STARTUP] Recording metric for phase: initialize_mcp_clients duration: 1005.4859529999999
+Token usage: unknown
+Waiting 30 seconds for rate limits...
+
+=== Showing ONBOARDING.md for searxng ===
+=== Repo: searxng ===
+# ONBOARDING.md
+
+## Overview
+Repo path: /home/rogermt/searxng
+
+## Environment setup
+Python version: 3.14
+
+## Install dependencies
+* `make install` (Install dependencies via Makefile target.)
+
+## Run / develop locally
+* `make run` (Run the application via Makefile target.)
+
+## Run tests
+* `make test` (Run the test suite via Makefile target.)
+
+## Lint / format
+* `make format` (Run formatting via Makefile target.)
+
+## Analyzer notes
+* docs list truncated to 10 entries (total=174)
+
+## Dependency files detected
+* requirements.txt (Python dependency manifest.)
+* requirements-dev.txt (Python dependency manifest.)
+* requirements-server.txt (Python dependency manifest.)
+* setup.py (Packaging/build configuration (setuptools).)
+
+## Useful configuration files
+* Makefile (Primary task runner for development and build orchestration.)
+* .github/workflows/checker.yml (CI/CD automation workflow.)
+* .github/workflows/container.yml (CI/CD automation workflow.)
+* .github/workflows/data-update.yml (CI/CD automation workflow.)
+* .github/workflows/documentation.yml (CI/CD automation workflow.)
+* .github/workflows/integration.yml (CI/CD automation workflow.)
+* .github/workflows/l10n.yml (CI/CD automation workflow.)
+
+## Useful docs
+* CONTRIBUTING.rst
+* LICENSE
+* README.rst
+* SECURITY.md
+* docs/index.rst
+* docs/own-instance.rst
+* docs/dev/quickstart.rst
+* docs/admin/installation-apache.rst
+* docs/admin/installation-docker.rst
+* docs/admin/installation-granian.rst
+
+--- Validating ONBOARDING.md for searxng ---
+Validation passed for /home/rogermt/searxng/ONBOARDING.md.
 
 === Showing ONBOARDING.md for Paper2Code ===
 === Repo: Paper2Code ===
@@ -63,5 +179,146 @@ No explicit commands detected.
 * README.md
 * data/paper2code/README.md
 * notebooks/README.md
+
+--- Validating ONBOARDING.md for Paper2Code ---
+Validation passed for /home/rogermt/Paper2Code/ONBOARDING.md.
+
+=== Showing ONBOARDING.md for imgix-python ===
+=== Repo: imgix-python ===
+# ONBOARDING.md
+
+## Overview
+Repo path: /home/rogermt/imgix-python
+
+## Environment setup
+No Python version pin detected.
+(Generic suggestion)
+* `python3 -m venv .venv` (Create virtual environment.)
+* `source .venv/bin/activate` (Activate virtual environment.)
+
+## Install dependencies
+* `pip install -e .` (Install the project in editable mode.)
+
+## Run / develop locally
+No explicit commands detected.
+
+## Run tests
+* `tox` (Run tests via tox.)
+
+## Lint / format
+* `tox -e flake8` (Run flake8 linting via tox.)
+
+## Dependency files detected
+* setup.cfg (Packaging/build configuration (setuptools).)
+* setup.py (Packaging/build configuration (setuptools).)
+
+## Useful configuration files
+* tox.ini (Test environment orchestrator (tox).)
+* .github/workflows/add-issue-to-project.yml (CI/CD automation workflow.)
+* .github/workflows/add-pr-to-project.yml (CI/CD automation workflow.)
+
+## Useful docs
+* CONTRIBUTING.md
+* LICENSE
+* README.md
+
+--- Validating ONBOARDING.md for imgix-python ---
+Validation passed for /home/rogermt/imgix-python/ONBOARDING.md.
+
+=== Showing ONBOARDING.md for wagtail ===
+=== Repo: wagtail ===
+# ONBOARDING.md
+
+## Overview
+Repo path: /home/rogermt/wagtail
+
+## Environment setup
+No Python version pin detected.
+(Generic suggestion)
+* `python3 -m venv .venv` (Create virtual environment.)
+* `source .venv/bin/activate` (Activate virtual environment.)
+
+## Install dependencies
+* `pip install .` (Install the project package.)
+
+## Run / develop locally
+* `bash scripts/fetch-translations.sh` (Delete old translation files (except "en" which is the source translation).)
+* `bash scripts/rebuild-translation-sources.sh` (Delete old translation sources.)
+
+## Run tests
+* `make test` (Run the test suite via Makefile target.)
+* `bash scripts/latest.sh` (Run repo script entrypoint.)
+* `tox` (Run tests via tox.)
+
+## Lint / format
+* `make lint` (Run linting via Makefile target.)
+* `make format` (Run formatting via Makefile target.)
+
+## Analyzer notes
+* docs list truncated to 10 entries (total=366)
+* Frameworks detected (from analyzer): Django, Wagtail. (Detected via pyproject.toml classifiers.)
+
+## Dependency files detected
+* pyproject.toml (Project configuration and dependency management (PEP 518/621).)
+* wagtail/project_template/requirements.txt (Python dependency manifest.)
+* setup.py (Packaging/build configuration (setuptools).)
+
+## Useful configuration files
+* Makefile (Primary task runner for development and build orchestration.)
+* .pre-commit-config.yaml (Pre-commit hooks configuration (code quality automation).)
+* tox.ini (Test environment orchestrator (tox).)
+* .github/workflows/codeql-analysis.yml (CI/CD automation workflow.)
+* .github/workflows/test.yml (CI/CD automation workflow.)
+
+## Useful docs
+* LICENSE
+* README.md
+* docs/README.md
+* docs/index.rst
+* docs/spelling_wordlist.txt
+* docs/support.md
+* docs/advanced_topics/third_party_tutorials.md
+* docs/getting_started/quick_install.md
+* docs/getting_started/tutorial.md
+* docs/tutorial/add_search.md
+
+--- Validating ONBOARDING.md for wagtail ---
+Validation passed for /home/rogermt/wagtail/ONBOARDING.md.
+
+=== Showing ONBOARDING.md for connexion ===
+=== Repo: connexion ===
+# ONBOARDING.md
+
+## Overview
+Repo path: (unknown)
+
+## Environment setup
+No Python version pin detected.
+(Generic suggestion)
+* `python3 -m venv .venv` (Create virtual environment.)
+* `source .venv/bin/activate` (Activate virtual environment.)
+
+## Install dependencies
+No explicit commands detected.
+
+## Run / develop locally
+No explicit commands detected.
+
+## Run tests
+No explicit commands detected.
+
+## Lint / format
+No explicit commands detected.
+
+## Dependency files detected
+No dependency files detected.
+
+## Useful configuration files
+No useful configuration files detected.
+
+## Useful docs
+No useful docs detected.
+--- Validating ONBOARDING.md for connexion ---
+Validation passed for /home/rogermt/connexion/ONBOARDING.md.
 
 === Evaluation complete ===

--- a/src/mcp_repo_onboarding/analysis/catalog.py
+++ b/src/mcp_repo_onboarding/analysis/catalog.py
@@ -5,15 +5,21 @@ This module breaks a circular dependency between core and other modules
 by providing a neutral location for classification functions.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
-from ..config import DEPENDENCY_FILE_TYPES
+from ..config import classify_filename
 
 
 def is_dependency_file(path: str) -> bool:
-    """Check if a file is canonically a dependency manifest."""
+    """
+    Check if a file is canonically a dependency manifest.
+
+    Behavior preserved:
+    - exact-name dependency classification via config.classify_filename
+    - requirements*.txt / requirements*.in treated as dependency manifests
+    """
     path = path.replace("\\", "/").lstrip("/")
-    name = Path(path).name.lower()
-    return name in DEPENDENCY_FILE_TYPES or (
-        name.startswith("requirements") and name.endswith((".txt", ".in"))
-    )
+    name = Path(path).name
+    return classify_filename(name) == "dependency"

--- a/src/mcp_repo_onboarding/config.py
+++ b/src/mcp_repo_onboarding/config.py
@@ -2,17 +2,22 @@
 Configuration constants for the repository analysis module.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
 # Maximum number of documentation files to include in the analysis report
-MAX_DOCS_CAP = 10
+MAX_DOCS_CAP: Final[int] = 10
 
 # Maximum number of configuration files to include in the analysis report
-MAX_CONFIG_CAP = 15
+MAX_CONFIG_CAP: Final[int] = 15
 
 # Default maximum number of files to scan if not specified
-DEFAULT_MAX_FILES = 5000
+DEFAULT_MAX_FILES: Final[int] = 5000
 
 # Patterns to always ignore for safety and noise reduction
-SAFETY_IGNORES = [
+SAFETY_IGNORES: Final[list[str]] = [
     "tests/fixtures/",
     "test/fixtures/",
     ".git/",
@@ -31,32 +36,98 @@ SAFETY_IGNORES = [
     ".coverage",
 ]
 
-# Configuration files — NO overlap with DEPENDENCY_FILE_TYPES per §2
-# NOTE: pyproject.toml, setup.py, setup.cfg are classified as DEPS, not configs
-CONFIG_FILE_TYPES = {
-    "makefile",
-    "tox.ini",
-    "noxfile.py",
-    ".pre-commit-config.yaml",
-    ".pre-commit-config.yml",
-    "pytest.ini",
-    "pytest.cfg",
+# =============================================================================
+# File classification (Single Source of Truth)
+#
+# Goal for #78:
+# - Replace duplicated/manual overlapping sets with a single authoritative mapping.
+# - Derive CONFIG_FILE_TYPES and DEPENDENCY_FILE_TYPES from that mapping.
+# - Keep behavior unchanged.
+#
+# Contract: dependency files must never appear in configurationFiles output.
+# =============================================================================
+
+FileCategory = Literal["config", "dependency"]
+
+
+@dataclass(frozen=True)
+class FileKind:
+    category: FileCategory
+
+
+# Authoritative mapping for exact filename classification (lowercase keys).
+# NOTE: Keep this aligned with existing behavior (no surprise additions).
+FILE_KINDS: Final[dict[str, FileKind]] = {
+    # -------------------------
+    # Config files
+    # -------------------------
+    "makefile": FileKind(category="config"),
+    "tox.ini": FileKind(category="config"),
+    "noxfile.py": FileKind(category="config"),
+    ".pre-commit-config.yaml": FileKind(category="config"),
+    ".pre-commit-config.yml": FileKind(category="config"),
+    "pytest.ini": FileKind(category="config"),
+    "pytest.cfg": FileKind(category="config"),
+    # NOTE: pyproject.toml/setup.py/setup.cfg intentionally NOT config (deps only)
+    # -------------------------
+    # Dependency files
+    # -------------------------
+    "requirements.txt": FileKind(category="dependency"),
+    "requirements-dev.txt": FileKind(category="dependency"),
+    "requirements-server.txt": FileKind(category="dependency"),
+    "pyproject.toml": FileKind(category="dependency"),
+    "setup.py": FileKind(category="dependency"),
+    "setup.cfg": FileKind(category="dependency"),
+    "pipfile": FileKind(category="dependency"),
+    "environment.yml": FileKind(category="dependency"),
+    "environment.yaml": FileKind(category="dependency"),
 }
 
-# Dependency files — canonical list per EXTRACT_OUTPUT_RULES.md §2
-DEPENDENCY_FILE_TYPES = {
-    "requirements.txt",
-    "requirements-dev.txt",
-    "requirements-server.txt",
-    "pyproject.toml",
-    "setup.py",
-    "setup.cfg",
-    "pipfile",
-    "environment.yml",
-    "environment.yaml",
-}
+# Derived disjoint sets used throughout the codebase (exact filenames only).
+CONFIG_FILE_TYPES: Final[frozenset[str]] = frozenset(
+    name for name, kind in FILE_KINDS.items() if kind.category == "config"
+)
+DEPENDENCY_FILE_TYPES: Final[frozenset[str]] = frozenset(
+    name for name, kind in FILE_KINDS.items() if kind.category == "dependency"
+)
+
+_overlap = CONFIG_FILE_TYPES & DEPENDENCY_FILE_TYPES
+if _overlap:
+    raise RuntimeError(f"config.py invariant violated: overlapping file types: {_overlap}")
+
+# Prefix-based dependency detection (preserve existing behavior in catalog.py):
+# - requirements*.txt / requirements*.in
+DEPENDENCY_PREFIXES: Final[tuple[str, ...]] = ("requirements",)
+DEPENDENCY_SUFFIXES: Final[tuple[str, ...]] = (".txt", ".in")
+
+
+def classify_filename(name: str) -> FileCategory | None:
+    """
+    Classify a repo file *name* (not a path), case-insensitive.
+
+    Returns:
+        "config" | "dependency" | None
+
+    Behavior is designed to match existing logic:
+    - Exact-name matches via FILE_KINDS
+    - requirements*.txt / requirements*.in treated as dependency manifests
+    """
+    n = name.lower()
+
+    kind = FILE_KINDS.get(n)
+    if kind is not None:
+        return kind.category
+
+    if any(n.startswith(pfx) for pfx in DEPENDENCY_PREFIXES) and any(
+        n.endswith(sfx) for sfx in DEPENDENCY_SUFFIXES
+    ):
+        return "dependency"
+
+    return None
+
+
 # Extensions to exclude from documentation entirely
-DOC_EXCLUDED_EXTENSIONS = {
+DOC_EXCLUDED_EXTENSIONS: Final[set[str]] = {
     ".png",
     ".jpg",
     ".jpeg",
@@ -82,7 +153,7 @@ DOC_EXCLUDED_EXTENSIONS = {
 }
 
 # Extensions considered "human documentation" under docs/ directory
-DOC_HUMAN_EXTENSIONS = {
+DOC_HUMAN_EXTENSIONS: Final[set[str]] = {
     ".md",
     ".rst",
     ".txt",
@@ -90,7 +161,7 @@ DOC_HUMAN_EXTENSIONS = {
 }
 
 # Mapping of tool keys and build backend identifiers to package manager names
-KNOWN_PACKAGE_MANAGERS = {
+KNOWN_PACKAGE_MANAGERS: Final[dict[str, str]] = {
     "poetry": "poetry",
     "hatch": "hatch",
     "pdm": "pdm",

--- a/tests/test_config_classification.py
+++ b/tests/test_config_classification.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from mcp_repo_onboarding.config import (
+    CONFIG_FILE_TYPES,
+    DEPENDENCY_FILE_TYPES,
+    classify_filename,
+)
+
+
+def test_config_and_dependency_sets_are_disjoint() -> None:
+    assert CONFIG_FILE_TYPES.isdisjoint(DEPENDENCY_FILE_TYPES)
+
+
+def test_pyproject_is_dependency_only() -> None:
+    # Classification API
+    assert classify_filename("pyproject.toml") == "dependency"
+
+    # Derived sets (exact-name lists)
+    assert "pyproject.toml" in DEPENDENCY_FILE_TYPES
+    assert "pyproject.toml" not in CONFIG_FILE_TYPES
+
+
+def test_known_configs_are_config() -> None:
+    assert classify_filename("tox.ini") == "config"
+    assert classify_filename(".pre-commit-config.yaml") == "config"
+    assert classify_filename("Makefile") == "config"
+
+
+def test_requirements_prefix_is_dependency() -> None:
+    # These are not necessarily in DEPENDENCY_FILE_TYPES (only exact names are),
+    # but they must be classified as dependencies for categorization.
+    assert classify_filename("requirements.txt") == "dependency"
+    assert classify_filename("requirements-dev.txt") == "dependency"
+    assert classify_filename("requirements.in") == "dependency"
+    assert classify_filename("requirements-dev.in") == "dependency"


### PR DESCRIPTION
…ification

- Introduce FILE_KINDS: dict[str, FileKind] as authoritative classification mapping
- Derive CONFIG_FILE_TYPES and DEPENDENCY_FILE_TYPES as immutable, disjoint sets
- Update catalog.is_dependency_file() to use FILE_KINDS
- Eliminate overlap guards (none needed with centralized source of truth)
- All tests passing, evaluation suite validated (5/5)

```markdown
# Title

## Summary

Briefly describe what this PR changes or adds.

## Related issues

- Closes #(issue-number) or related to #(issue-number)

## Changes

- [ ] Code changes in `src/...`
- [ ] Tests added/updated in `test/...`
- [ ] Docs updated (README/CONTRIBUTING/etc.)

Describe the key changes:

- ...
- ...

## How to test

Steps or commands you used to verify this PR:

```bash
npm test
# and optionally
npm run build
# and any Gemini MCP flows you exercised
```

If applicable, mention specific fixture repos or real-world repos you tested on.

## Checklist

- [ ] I’ve read the scope and non‑goals in the README/design docs.
- [ ] My changes stay within the project’s responsibilities (env/deps/run/test).
- [ ] `npm test` passes locally.
- [ ] I’ve added or updated tests for any new behavior.
```
