### PR TITLE
fix(#102): Remove evaluation_results.log from .gitignore to allow tra…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,4 @@ htmlcov/
 # Local-only artifacts (not committed)
 scratch/
 *.gitingest.txt
-evaluation_results.log
 error.log


### PR DESCRIPTION
Remove evaluation_results.log from .gitignore to allow tracking of evl runs

Closes #102