### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## v0.1.0
+
+### Scope
+- Python-first onboarding generation (validator-compliant, deterministic output).
+
+### Added
+- Framework detection improvements:
+  - Detect Streamlit and Gradio from `requirements*.txt` (evidence-based).
+- Polyglot awareness (evidence-only):
+  - “Other tooling detected” section surfaces secondary tooling based on evidence files only.
+  - Evidence lists are deterministically sorted and truncated with explicit wording.
+- Onboarding readability improvements:
+  - Notebook directory listings are deterministically capped with a truncation note.
+- Python-only scope guard:
+  - When Python tooling is not detected, ONBOARDING includes a neutral note indicating Python-only scope.
+
+### Changed
+- Bash script descriptions:
+  - Improved deterministic fallback descriptions for common helper scripts (prevents “No description provided by analyzer.” in common cases).
+
+### Notes
+- No non-Python commands are suggested (no npm/yarn/pnpm instructions).
+- No subprocess execution; no network calls.
+
+### Next
+- Phase 10: non-Python-primary onboarding (e.g., Node-first repos), including primary tooling selection.


### PR DESCRIPTION
## Summary

This PR marks the v0.1.0 release by establishing the `CHANGELOG.md`. It officially documents the completion of the Python-first onboarding generation 
  phase, highlighting improvements in framework detection, deterministic output, and polyglot awareness.

## Related issues

- Release v0.1.0

## Changes

- [ ] Code changes in `src/...`
- [ ] Tests added/updated in `test/...`
- [x] Docs updated (CHANGELOG.md)

### Key Changes:

- **Changelog Creation**: Added `CHANGELOG.md` with v0.1.0 details.
- **Scope Definition**: Documented the "Python-first" scope and guardrails.
- **Feature Documentation**: Detailed improvements in:
  - Framework detection (Streamlit, Gradio).
  - Polyglot evidence surfacing.
  - Deterministic output (notebooks, file lists).
  - Bash script fallback descriptions.

## How to test

Review the `CHANGELOG.md` file to ensure it accurately reflects the release contents and formatting.

## Checklist

- [x] I’ve read the scope and non‑goals in the README/design docs.
- [x] My changes stay within the project’s responsibilities (env/deps/run/test).
- [x] `uv run pytest` passes locally.
- [x] I’ve added or updated tests for any new behavior.
```

If you want this tightened into a more polished PR body or converted into a conventional commit message, I can do that too.

