### PR TITLE
feat(#124): Add primaryTooling field and evidence-based detection logic

### DIFF
--- a/src/mcp_repo_onboarding/schema.py
+++ b/src/mcp_repo_onboarding/schema.py
@@ -134,6 +134,7 @@ class RepoAnalysis(BaseModel):
     """Top-level analysis result for a repository."""
 
     repoPath: str
+    primaryTooling: str | None = None  # Phase 10 scaffolding (#124)
     languages: list[LanguageStat] = Field(default_factory=list)
     python: PythonInfo | None = None
     projectLayout: ProjectLayout = Field(default_factory=ProjectLayout)

--- a/tests/analysis/core/test_primary_tooling.py
+++ b/tests/analysis/core/test_primary_tooling.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcp_repo_onboarding.analysis import analyze_repo
+
+
+def test_primary_tooling_node_first(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # Node evidence (stronger than Python)
+    (repo / "package.json").write_text('{"name":"x","version":"0.0.0"}', encoding="utf-8")
+    (repo / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    a = analyze_repo(str(repo))
+    assert a.primaryTooling == "Node.js"
+
+
+def test_primary_tooling_python_first(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # Python evidence (stronger than Node)
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.0.0'\n", encoding="utf-8")
+
+    a = analyze_repo(str(repo))
+    assert a.primaryTooling == "Python"
+
+
+def test_primary_tooling_tie_breaks_to_python(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # Tie: Python +10 (pyproject.toml) vs Node +10 (lockfile only)
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.0.0'\n", encoding="utf-8")
+    (repo / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    a = analyze_repo(str(repo))
+    assert a.primaryTooling == "Python"
+
+
+def test_primary_tooling_unknown_when_no_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    a = analyze_repo(str(repo))
+    assert a.primaryTooling == "Unknown"
+
+
+def test_primary_tooling_deterministic_across_runs(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    (repo / "package.json").write_text('{"name":"x"}', encoding="utf-8")
+    (repo / "pnpm-lock.yaml").write_text("lockfileVersion: 6", encoding="utf-8")
+    (repo / "requirements.txt").write_text("requests\n", encoding="utf-8")
+
+    a1 = analyze_repo(str(repo))
+    a2 = analyze_repo(str(repo))
+
+    assert a1.primaryTooling == a2.primaryTooling


### PR DESCRIPTION
PR Title:

feat(#124): Add primaryTooling field and evidence-based detection logic
PR Description:

## Overview
Add `primaryTooling` field to RepoAnalysis with deterministic, evidence-only detection. Values: "Python", "Node.js", or "Unknown".

## Changes

### Schema (`src/mcp_repo_onboarding/schema.py`)
- Added `primaryTooling: str | None = None` field to RepoAnalysis (positioned after repoPath for easy discovery)

### Analysis Core (`src/mcp_repo_onboarding/analysis/core.py`)
- Added `_compute_primary_tooling_from_files(all_files: list[str]) -> str` function
  - Data-driven evidence patterns (cleaner than if/else chains)
  - Python scoring: pyproject.toml (10), requirements*.txt (6), setup.py/setup.cfg (5), lockfile (8)
  - Node scoring: package.json (5), lockfile (10), .nvmrc/.node-version (3)
  - Tie-break: Python wins
- Integrated into `analyze_repo()` pipeline (called after combining all_files)

### Tests (`tests/analysis/core/test_primary_tooling.py`)
- 5 test cases:
  - Node-first repo (package.json + lockfile)
  - Python-first repo (pyproject.toml)
  - Tie-break to Python
  - Unknown when no evidence
  - Deterministic across runs

## Design Notes
- Evidence-only: no inference, no file reads beyond file list
- Data-driven pattern matching: easy to extend for future tooling
- Deterministic and reproducible across runs
- No changes to validator contract

## Testing
- 248 tests pass
- Coverage: 88.50% (exceeds 80% requirement)
- All linters pass

## Closes
- #124
