### PR TITLE
fix(#151): Remove duplicate node-primary-min fixture creation blocks from eval scripts

### DIFF
--- a/scripts/run_headless_evaluation.sh
+++ b/scripts/run_headless_evaluation.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Phase 10: Node-primary repo fixture (ensure it exists)
-FIXTURE_DIR="evaluation_repos/node-primary-min"
-if [ ! -d "$HOME/$FIXTURE_DIR" ]; then
-  echo "INFO: Creating local fixture for $FIXTURE_DIR..."
-  mkdir -p "$HOME/$FIXTURE_DIR"
-  if [ ! -f "$HOME/$FIXTURE_DIR/package.json" ]; then
-    echo "{}" > "$HOME/$FIXTURE_DIR/package.json"
-  fi
-  touch "$HOME/$FIXTURE_DIR/package-lock.json"
-fi
-
 # Read repo list from file if no args provided
 if [ "$#" -gt 0 ]; then
   repos=("$@")

--- a/scripts/validate_onboarding_list.sh
+++ b/scripts/validate_onboarding_list.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Phase 10: Node-primary repo fixture (ensure it exists)
-FIXTURE_DIR="evaluation_repos/node-primary-min"
-if [ ! -d "$HOME/$FIXTURE_DIR" ]; then
-  echo "INFO: Creating local fixture for $FIXTURE_DIR..."
-  mkdir -p "$HOME/$FIXTURE_DIR"
-  if [ ! -f "$HOME/$FIXTURE_DIR/package.json" ]; then
-    echo "{}" > "$HOME/$FIXTURE_DIR/package.json"
-  fi
-  touch "$HOME/$FIXTURE_DIR/package-lock.json"
-fi
-
 # Read repo list from file if no args provided
 if [ "$#" -gt 0 ]; then
   repos=("$@")


### PR DESCRIPTION
## Problem

Both eval scripts created a duplicate fixture at `$HOME/evaluation_repos/node-primary-min` with empty package.json:
- **scripts/run_headless_evaluation.sh** (lines 4-13)
- **scripts/validate_onboarding_list.sh** (lines 4-13)

But the real fixture is created by **scripts/setup_evaluation_repos.sh** at `$HOME/node-primary-min` with proper scripts and lockfile.

This duplication caused:
1. Silent test failures (wrong repo path)
2. Non-deterministic behavior (empty vs real package.json)
3. Confusion about single source of truth

## Solution

- Deleted 10-line Phase 10 fixture block from run_headless_evaluation.sh
- Deleted 10-line Phase 10 fixture block from validate_onboarding_list.sh
- Made setup_evaluation_repos.sh the single source of truth
- Both eval scripts already call setup_evaluation_repos.sh first (line 29 and 37 respectively)

## Changes

- **scripts/run_headless_evaluation.sh**: Removed lines 4-13 (duplicate fixture creation)
- **scripts/validate_onboarding_list.sh**: Removed lines 4-13 (duplicate fixture creation)
- Closes #151 

## Verification

✓ All scripts pass bash syntax validation
✓ 266 unit tests pass
✓ No behavior change (setup already called by both scripts)

## Acceptance Criteria

- [x] No script creates $HOME/evaluation_repos/node-primary-min
- [x] node-primary-min is created only by setup_evaluation_repos.sh
- [x] Eval scripts maintain proper node-primary-min assertions