### PR TITLE
feat(#146): Suppress primary tooling from ## Other tooling detected section

### DIFF
--- a/tests/onboarding/test_registry_suppression.py
+++ b/tests/onboarding/test_registry_suppression.py
@@ -1,0 +1,129 @@
+"""
+Tests for registry suppression logic (Issue #146).
+
+Verifies that _other_tooling_lines() suppresses primary tooling from the
+"## Other tooling detected" section and ensures deterministic sorting.
+"""
+
+from __future__ import annotations
+
+from mcp_repo_onboarding.analysis.onboarding_blueprint_engine.context import Context
+from mcp_repo_onboarding.analysis.onboarding_blueprint_engine.registry import (
+    _other_tooling_lines,
+)
+
+
+def test_suppresses_primary_tooling() -> None:
+    """Primary tooling should not appear in ## Other tooling detected section."""
+    analyze = {
+        "primaryTooling": "Node.js",
+        "otherTooling": [
+            {"name": "Node.js", "evidenceFiles": ["package.json"]},
+            {"name": "Go", "evidenceFiles": ["go.mod"]},
+        ],
+    }
+    ctx = Context(analyze=analyze, commands={})
+    lines = _other_tooling_lines(ctx)
+
+    # Should contain Go
+    assert any("Go" in line for line in lines), f"Go not found in {lines}"
+    # Should NOT contain Node.js (suppressed as primary)
+    assert not any("Node.js" in line for line in lines), f"Node.js should be suppressed in {lines}"
+
+
+def test_no_suppression_if_primary_differs() -> None:
+    """If primary tooling is different, other tooling should appear normally."""
+    analyze = {
+        "primaryTooling": "Python",
+        "otherTooling": [{"name": "Node.js", "evidenceFiles": ["package.json"]}],
+    }
+    ctx = Context(analyze=analyze, commands={})
+    lines = _other_tooling_lines(ctx)
+
+    assert any("Node.js" in line for line in lines), f"Node.js not found in {lines}"
+
+
+def test_deterministic_sorting_by_name() -> None:
+    """Tooling items should be sorted alphabetically by name."""
+    analyze = {
+        "primaryTooling": "Python",
+        "otherTooling": [
+            {"name": "Node.js", "evidenceFiles": ["package.json"]},
+            {"name": "Docker", "evidenceFiles": ["Dockerfile"]},
+            {"name": "Go", "evidenceFiles": ["go.mod"]},
+        ],
+    }
+    ctx = Context(analyze=analyze, commands={})
+    lines = _other_tooling_lines(ctx)
+
+    # Extract tooling names in order they appear
+    names = []
+    for line in lines:
+        # Lines are like "* Docker (Dockerfile)"
+        stripped = line.strip("* ").split(" (")[0]
+        names.append(stripped)
+
+    # Should be in alphabetical order: Docker, Go, Node.js
+    assert names == ["Docker", "Go", "Node.js"], f"Expected sorted order, got {names}"
+
+
+def test_evidence_file_sorting() -> None:
+    """Evidence files within a tooling entry should be sorted lexicographically."""
+    analyze = {
+        "primaryTooling": "Python",
+        "otherTooling": [
+            {
+                "name": "Go",
+                "evidenceFiles": ["go.sum", "go.mod", "Dockerfile"],
+            }
+        ],
+    }
+    ctx = Context(analyze=analyze, commands={})
+    lines = _other_tooling_lines(ctx)
+
+    assert len(lines) == 1
+    line = lines[0]
+
+    # Evidence should be sorted: Dockerfile, go.mod, go.sum
+    assert "Dockerfile" in line
+    assert "go.mod" in line
+    assert "go.sum" in line
+
+    # Check order in string
+    dockerfile_idx = line.index("Dockerfile")
+    go_mod_idx = line.index("go.mod")
+    go_sum_idx = line.index("go.sum")
+
+    assert dockerfile_idx < go_mod_idx < go_sum_idx, (
+        f"Evidence files should be sorted, but got order: "
+        f"Dockerfile@{dockerfile_idx}, go.mod@{go_mod_idx}, go.sum@{go_sum_idx}"
+    )
+
+
+def test_empty_other_tooling() -> None:
+    """Empty otherTooling should return empty lines list."""
+    analyze = {
+        "primaryTooling": "Python",
+        "otherTooling": [],
+    }
+    ctx = Context(analyze=analyze, commands={})
+    lines = _other_tooling_lines(ctx)
+
+    assert lines == []
+
+
+def test_primary_tooling_case_sensitive_match() -> None:
+    """Suppression should match primary tooling exactly (case-sensitive)."""
+    analyze = {
+        "primaryTooling": "node.js",  # lowercase
+        "otherTooling": [
+            {"name": "Node.js", "evidenceFiles": ["package.json"]},  # mixed case
+        ],
+    }
+    ctx = Context(analyze=analyze, commands={})
+    lines = _other_tooling_lines(ctx)
+
+    # Names are different cases, so Node.js should NOT be suppressed
+    assert any("Node.js" in line for line in lines), (
+        "Node.js should appear (primary is 'node.js' which is different case)"
+    )


### PR DESCRIPTION
## Problem

When primaryTooling == "Node.js", ONBOARDING shows:

1. **## Analyzer notes** section: "Primary tooling: Node.js (package.json, pnpm-lock.yaml present)."
2. **## Other tooling detected** section: Lists Node.js again with evidence files

This violates Phase 10 UX goal: no redundant primary info.

## Solution

### Implementation
Updated `_other_tooling_lines()` in `src/mcp_repo_onboarding/analysis/onboarding_blueprint_engine/registry.py`:

- **Filter**: Exclude tooling entries where `name == primaryTooling`
- **Sort**: Deterministically sort remaining tooling by name (alphabetically)
- **Evidence**: Maintain lexicographic sorting of file paths (unchanged)

### Result
- Primary tooling only appears in ## Analyzer notes (single source of truth)
- "## Other tooling detected" section is suppressed if only primary tooling would appear
- Deterministic ordering prevents non-reproducible diffs

## Tests

### New Test File: `tests/onboarding/test_registry_suppression.py`
6 test cases following TDD (tests written first):
- `test_suppresses_primary_tooling` — Node.js suppressed when primary
- `test_no_suppression_if_primary_differs` — Python-primary repos still show Node.js
- `test_deterministic_sorting_by_name` — Alphabetic order: Docker, Go, Node.js
- `test_evidence_file_sorting` — Evidence paths sorted lexicographically
- `test_empty_other_tooling` — Handles empty lists
- `test_primary_tooling_case_sensitive_match` — Exact match required

### Updated Existing Test: `test_other_tooling_normalization.py`
- `test_gradio_bbox_node_tooling_normalized` — Updated to verify suppression
  - Confirms ## Other tooling detected NOT present (primary suppressed)
  - Confirms Primary tooling note appears in ## Analyzer notes

## Verification

✅ **Tests**: 272 passed (1 new test file, 1 updated test)  
✅ **Coverage**: 89.34% (exceeds 80% minimum)  
✅ **Linting**: ruff check, ruff format, mypy all clean  
✅ **TDD**: Red → Green → Refactor workflow followed  

## Acceptance Criteria

- [x] Node-primary repos do not print Node.js under ## Other tooling detected
- [x] Python-primary repos still print Node.js evidence in ## Other tooling detected
- [x] Output remains deterministic (sorted by name, then by evidence paths)
- [x] Tests verify suppression logic works correctly