### PR TITLE
fix(#161): Fix eval_repos.list parsing in run_headless_evaluation.sh

### DIFF
--- a/scripts/run_headless_evaluation.sh
+++ b/scripts/run_headless_evaluation.sh
@@ -6,7 +6,16 @@ if [ "$#" -gt 0 ]; then
   repos=("$@")
 else
   if [ -f "scripts/eval_repos.list" ]; then
-    mapfile -t < scripts/eval_repos.list repos
+    # Parse eval_repos.list: extract repo names (first field, pipe-delimited)
+    # Skip comments and blank lines
+    repos=()
+    while IFS='|' read -r repo_name _ _ _; do
+      # Skip empty lines and comments
+      [[ -z "$repo_name" || "$repo_name" =~ ^# ]] && continue
+      # Trim whitespace
+      repo_name=$(echo "$repo_name" | xargs)
+      repos+=("$repo_name")
+    done < scripts/eval_repos.list
   else
     echo "ERROR: No repositories provided and scripts/eval_repos.list not found."
     exit 1


### PR DESCRIPTION
## Issue
run_headless_evaluation.sh was using `mapfile` which read the entire eval_repos.list lines as-is, including comments and pipe-delimited metadata. This caused directory paths like:
- `/home/rogermt/# Evaluation repositories - single source of truth`
- `/home/rogermt/searxng|https://github.com/searxng/searxng.git|main|Y`

## Fix
Updated eval_repos.list parsing to:
- Extract only the first field (repo_name) from pipe-delimited format
- Skip comments and blank lines
- Trim whitespace

Now correctly extracts: `searxng`, `Paper2Code`, etc.